### PR TITLE
Implement Phase P0 scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# SimpleSpecs — Phase P0
+
+Phase P0 establishes the project structure, configuration contracts, and mock endpoints for the UNO-less parsing stack with an optional MinerU toggle.
+
+## Prerequisites
+- Python 3.12+
+
+## Setup
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install fastapi uvicorn sqlmodel pydantic pydantic-settings httpx
+```
+
+## Running the API
+```bash
+uvicorn backend.main:create_app --factory --host 127.0.0.1 --port 8000
+```
+
+Then open [http://127.0.0.1:8000/frontend/](http://127.0.0.1:8000/frontend/) to view the scaffolded UI.
+
+## Configuration
+Set environment variables to override defaults:
+- `PDF_ENGINE` — `native`, `mineru`, or `auto`
+- `MINERU_ENABLED` — enables MinerU integration when set to `true`
+- `MINERU_MODEL_OPTS` — JSON-encoded options for MinerU models
+
+## Tests
+```bash
+pytest -q
+```

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,41 @@
+"""Application configuration settings."""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any, Literal
+
+try:  # pragma: no cover - fallback for environments without pydantic-settings
+    from pydantic_settings import BaseSettings
+except ImportError:  # pragma: no cover
+    from pydantic import BaseModel as BaseSettings  # type: ignore
+
+from pydantic import Field
+
+
+PdfEngine = Literal["native", "mineru", "auto"]
+
+
+class Settings(BaseSettings):
+    """Runtime settings loaded from env."""
+
+    OPENROUTER_API_KEY: str | None = Field(default=None, env="OPENROUTER_API_KEY")
+    LLAMACPP_URL: str = Field(default="http://localhost:8080", env="LLAMACPP_URL")
+    DB_URL: str = Field(default="sqlite:///./simplespecs.db", env="DB_URL")
+    ARTIFACTS_DIR: str = Field(default="artifacts", env="ARTIFACTS_DIR")
+    ALLOW_ORIGINS: list[str] = Field(default_factory=lambda: ["*"], env="ALLOW_ORIGINS")
+    MAX_FILE_MB: int = Field(default=50, env="MAX_FILE_MB")
+    PDF_ENGINE: PdfEngine = Field(default="native", env="PDF_ENGINE")
+    MINERU_ENABLED: bool = Field(default=False, env="MINERU_ENABLED")
+    MINERU_MODEL_OPTS: dict[str, Any] = Field(default_factory=dict, env="MINERU_MODEL_OPTS")
+
+    model_config = {
+        "env_file": ".env",
+        "env_file_encoding": "utf-8",
+    }
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return a cached instance of :class:`Settings`."""
+
+    return Settings()

--- a/backend/logging.py
+++ b/backend/logging.py
@@ -1,0 +1,17 @@
+"""Logging configuration helpers."""
+from __future__ import annotations
+
+import logging
+from logging import Logger
+
+
+def setup_logging(level: int = logging.INFO) -> Logger:
+    """Configure the root logger for the application."""
+
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )
+    logger = logging.getLogger("simplespecs")
+    logger.debug("Logging configured", extra={"level": level})
+    return logger

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,65 @@
+"""FastAPI application factory for SimpleSpecs."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+from backend.config import Settings, get_settings
+from backend.logging import setup_logging
+from backend.routers.files import files_router
+from backend.routers.headers import headers_router
+from backend.routers.ingest import ingest_router
+from backend.routers.specs import specs_router
+from backend.routers.system import system_router
+
+
+FRONTEND_DIR = Path(__file__).resolve().parent.parent / "frontend"
+
+
+def create_app(settings: Settings | None = None) -> FastAPI:
+    """Create and configure the FastAPI application."""
+
+    setup_logging()
+    settings = settings or get_settings()
+
+    app = FastAPI(title="SimpleSpecs", version="0.1.0")
+    app.state.settings = settings
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.ALLOW_ORIGINS,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    if FRONTEND_DIR.exists():
+        app.mount("/frontend", StaticFiles(directory=FRONTEND_DIR, html=True), name="frontend")
+
+    @app.get("/", include_in_schema=False)
+    async def serve_index() -> FileResponse:
+        """Serve the frontend index file."""
+
+        index_file = FRONTEND_DIR / "index.html"
+        return FileResponse(index_file) if index_file.exists() else FileResponse("frontend/index.html")
+
+    @app.get("/healthz", summary="Health check")
+    async def healthz() -> dict[str, str]:
+        """Simple health check endpoint."""
+
+        return {"status": "ok"}
+
+    app.include_router(ingest_router)
+    app.include_router(files_router)
+    app.include_router(headers_router)
+    app.include_router(specs_router)
+    app.include_router(system_router)
+
+    return app
+
+
+__all__ = ["create_app"]

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,61 @@
+"""Pydantic schemas defining the public API contracts."""
+from __future__ import annotations
+
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ParsedObject(BaseModel):
+    """One extracted text/table/image object."""
+
+    object_id: str = Field(..., description="Stable identifier for the parsed object.")
+    file_id: str = Field(..., description="Identifier of the parent file.")
+    kind: Literal["text", "table", "image"] = Field(..., description="Type of content represented by the object.")
+    text: Optional[str] = Field(default=None, description="Extracted text, when available.")
+    page_index: Optional[int] = Field(default=None, description="Zero-based page index containing the object.")
+    bbox: Optional[list[float]] = Field(default=None, description="Bounding box [x0, y0, x1, y1] in PDF coordinates.")
+    order_index: int = Field(..., description="Linear order of the object within the document.")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Additional parser-specific metadata.")
+
+
+class SectionSpan(BaseModel):
+    """Span of parsed objects covered by a section."""
+
+    start_object: Optional[str] = Field(default=None, description="First parsed object id in the section span.")
+    end_object: Optional[str] = Field(default=None, description="Last parsed object id in the section span.")
+
+
+class SectionNode(BaseModel):
+    """Hierarchical section tree node."""
+
+    section_id: str = Field(..., description="Unique identifier for the section node.")
+    file_id: str = Field(..., description="Identifier of the file this section belongs to.")
+    number: Optional[str] = Field(default=None, description="Section numbering label if present.")
+    title: str = Field(..., description="Section title text.")
+    depth: int = Field(..., ge=0, description="Depth of the node in the hierarchy (root=0).")
+    children: list["SectionNode"] = Field(default_factory=list, description="Child section nodes.")
+    span: SectionSpan = Field(default_factory=SectionSpan, description="Span of parsed objects covered by the section.")
+
+
+class SpecItem(BaseModel):
+    """Structured specification item extracted from a section."""
+
+    spec_id: str = Field(..., description="Unique identifier for the specification item.")
+    file_id: str = Field(..., description="Identifier of the file the spec belongs to.")
+    section_id: str = Field(..., description="Section identifier the spec originated from.")
+    section_number: Optional[str] = Field(default=None, description="Numbering label of the parent section.")
+    section_title: str = Field(..., description="Title of the parent section.")
+    spec_text: str = Field(..., description="Extracted specification text content.")
+    confidence: Optional[float] = Field(default=None, ge=0.0, le=1.0, description="Confidence score supplied by the extractor.")
+    source_object_ids: list[str] = Field(default_factory=list, description="Identifiers of parsed objects supporting the spec.")
+
+
+class MockFileSummary(BaseModel):
+    """Summary payload used by mock routes for convenience."""
+
+    file_id: str
+    parsed_objects: list[ParsedObject]
+    sections: list[SectionNode]
+    specs: list[SpecItem]
+    pdf_engine: Literal["native", "mineru", "auto"]

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -1,0 +1,79 @@
+"""File-related routes."""
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from backend.models import MockFileSummary, ParsedObject, SectionNode, SectionSpan, SpecItem
+
+
+files_router = APIRouter(tags=["files"])
+
+
+def _mock_parsed_objects(file_id: str) -> list[ParsedObject]:
+    return [
+        ParsedObject(
+            object_id="obj-1",
+            file_id=file_id,
+            kind="text",
+            text="Mock paragraph content.",
+            page_index=0,
+            bbox=[0.0, 0.0, 100.0, 50.0],
+            order_index=0,
+            metadata={"source": "mock"},
+        )
+    ]
+
+
+def _mock_sections(file_id: str) -> list[SectionNode]:
+    root = SectionNode(
+        section_id="root",
+        file_id=file_id,
+        number=None,
+        title="Document Root",
+        depth=0,
+        children=[],
+        span=SectionSpan(start_object="obj-1", end_object="obj-1"),
+    )
+    return [root]
+
+
+def _mock_specs(file_id: str) -> list[SpecItem]:
+    return [
+        SpecItem(
+            spec_id="spec-1",
+            file_id=file_id,
+            section_id="root",
+            section_number=None,
+            section_title="Document Root",
+            spec_text="Mock specification for demonstration.",
+            confidence=None,
+            source_object_ids=["obj-1"],
+        )
+    ]
+
+
+@files_router.get("/parsed/{file_id}", response_model=list[ParsedObject], summary="Get parsed objects for a file.")
+def get_parsed_objects(file_id: str) -> list[ParsedObject]:
+    """Return mock parsed objects for a file."""
+
+    return _mock_parsed_objects(file_id)
+
+
+@files_router.post("/chunks/{file_id}", summary="Create chunk assignments for a file.")
+def create_chunks(file_id: str) -> dict[str, list[str]]:
+    """Return a mapping of section ids to parsed object ids."""
+
+    return {"root": [obj.object_id for obj in _mock_parsed_objects(file_id)]}
+
+
+@files_router.get("/files/{file_id}", response_model=MockFileSummary, summary="Summarise file processing state.")
+def get_file_summary(file_id: str) -> MockFileSummary:
+    """Return a combined summary of the mock processing state."""
+
+    return MockFileSummary(
+        file_id=file_id,
+        parsed_objects=_mock_parsed_objects(file_id),
+        sections=_mock_sections(file_id),
+        specs=_mock_specs(file_id),
+        pdf_engine="native",
+    )

--- a/backend/routers/headers.py
+++ b/backend/routers/headers.py
@@ -1,0 +1,46 @@
+"""Headers routes."""
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from backend.models import SectionNode, SectionSpan
+
+
+headers_router = APIRouter(prefix="/headers", tags=["headers"])
+
+
+def _mock_section_tree(file_id: str) -> SectionNode:
+    root = SectionNode(
+        section_id="root",
+        file_id=file_id,
+        number=None,
+        title="Document Root",
+        depth=0,
+        children=[],
+        span=SectionSpan(start_object=None, end_object=None),
+    )
+    intro = SectionNode(
+        section_id="intro",
+        file_id=file_id,
+        number="1",
+        title="Introduction",
+        depth=1,
+        children=[],
+        span=SectionSpan(start_object="obj-1", end_object="obj-3"),
+    )
+    root.children.append(intro)
+    return root
+
+
+@headers_router.get("/{file_id}", response_model=SectionNode, summary="Retrieve discovered headers for a file.")
+def get_headers(file_id: str) -> SectionNode:
+    """Return a mock section tree for the provided file identifier."""
+
+    return _mock_section_tree(file_id)
+
+
+@headers_router.post("/{file_id}/find", response_model=SectionNode, summary="Run header discovery on a file.")
+def find_headers(file_id: str) -> SectionNode:
+    """Return a mock section tree while simulating header discovery."""
+
+    return _mock_section_tree(file_id)

--- a/backend/routers/ingest.py
+++ b/backend/routers/ingest.py
@@ -1,0 +1,25 @@
+"""Ingest routes."""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from fastapi import APIRouter
+
+from backend.config import get_settings
+
+
+ingest_router = APIRouter(prefix="/ingest", tags=["ingest"])
+
+
+@ingest_router.post("", summary="Upload a file and create an ingestion record.")
+def ingest_file() -> dict[str, Any]:
+    """Mock ingestion endpoint returning a generated file identifier."""
+
+    file_id = f"file-{uuid.uuid4().hex[:8]}"
+    settings = get_settings()
+    return {
+        "file_id": file_id,
+        "status": "queued",
+        "pdf_engine": settings.PDF_ENGINE,
+    }

--- a/backend/routers/specs.py
+++ b/backend/routers/specs.py
@@ -1,0 +1,38 @@
+"""Specification routes."""
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from backend.models import SpecItem
+
+
+specs_router = APIRouter(prefix="/specs", tags=["specs"])
+
+
+def _mock_spec_items(file_id: str) -> list[SpecItem]:
+    return [
+        SpecItem(
+            spec_id="spec-1",
+            file_id=file_id,
+            section_id="intro",
+            section_number="1",
+            section_title="Introduction",
+            spec_text="The system shall provide a mock specification item.",
+            confidence=0.75,
+            source_object_ids=["obj-2"],
+        )
+    ]
+
+
+@specs_router.get("/{file_id}", response_model=list[SpecItem], summary="Retrieve stored specification items.")
+def get_specs(file_id: str) -> list[SpecItem]:
+    """Return mock specification items for the provided file."""
+
+    return _mock_spec_items(file_id)
+
+
+@specs_router.post("/{file_id}/find", response_model=list[SpecItem], summary="Run spec discovery on a file.")
+def find_specs(file_id: str) -> list[SpecItem]:
+    """Return mock specification items while simulating discovery."""
+
+    return _mock_spec_items(file_id)

--- a/backend/routers/system.py
+++ b/backend/routers/system.py
@@ -1,0 +1,28 @@
+"""System routes."""
+from __future__ import annotations
+
+import importlib
+import shutil
+
+from fastapi import APIRouter
+
+
+system_router = APIRouter(prefix="/system", tags=["system"])
+
+
+@system_router.get("/capabilities", summary="Report availability of optional tools.")
+def get_capabilities() -> dict[str, bool]:
+    """Return capability flags for optional external tooling."""
+
+    try:
+        importlib.import_module("mineru")
+        mineru_importable = True
+    except ImportError:  # pragma: no cover - depends on environment
+        mineru_importable = False
+
+    return {
+        "tesseract": shutil.which("tesseract") is not None,
+        "ghostscript": shutil.which("gs") is not None,
+        "java": shutil.which("java") is not None,
+        "mineru_importable": mineru_importable,
+    }

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -1,0 +1,26 @@
+"""LLM client protocol and adapter scaffolds."""
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class LLMAdapter(Protocol):
+    """Protocol describing the interface for language model adapters."""
+
+    def complete(self, prompt: str, *, temperature: float = 0.0, max_tokens: int | None = None) -> str:
+        """Produce a completion for the provided prompt."""
+
+
+class OpenRouterAdapter:
+    """Placeholder adapter for the OpenRouter API."""
+
+    def complete(self, prompt: str, *, temperature: float = 0.0, max_tokens: int | None = None) -> str:  # pragma: no cover
+        raise NotImplementedError("OpenRouter integration is implemented in a later phase")
+
+
+class LlamaCppAdapter:
+    """Placeholder adapter for a local llama.cpp server."""
+
+    def complete(self, prompt: str, *, temperature: float = 0.0, max_tokens: int | None = None) -> str:  # pragma: no cover
+        raise NotImplementedError("llama.cpp integration is implemented in a later phase")

--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -1,0 +1,42 @@
+"""PDF parser abstractions and selection logic."""
+from __future__ import annotations
+
+from typing import Protocol
+
+from backend.config import Settings
+from backend.models import ParsedObject
+
+
+class PdfParser(Protocol):
+    """Protocol describing a PDF parser implementation."""
+
+    def parse_pdf(self, file_path: str) -> list[ParsedObject]:
+        """Parse a PDF file and return parsed objects."""
+
+
+class NativePdfParser:
+    """Mock native PDF parser implementation."""
+
+    def parse_pdf(self, file_path: str) -> list[ParsedObject]:  # pragma: no cover - placeholder behaviour
+        return []
+
+
+class MinerUPdfParser:
+    """Mock MinerU PDF parser implementation."""
+
+    def parse_pdf(self, file_path: str) -> list[ParsedObject]:  # pragma: no cover - placeholder behaviour
+        return []
+
+
+def select_pdf_parser(settings: Settings, file_path: str) -> PdfParser:
+    """Select a PDF parser based on the configured engine."""
+
+    engine = settings.PDF_ENGINE
+    if engine == "native":
+        return NativePdfParser()
+    if engine == "mineru":
+        return MinerUPdfParser()
+    if engine == "auto":
+        return MinerUPdfParser() if settings.MINERU_ENABLED else NativePdfParser()
+
+    raise ValueError(f"Unsupported PDF engine: {engine}")

--- a/backend/store.py
+++ b/backend/store.py
@@ -1,0 +1,45 @@
+"""Database engine and session scaffolding."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+from backend.config import Settings, get_settings
+
+try:  # pragma: no cover - optional dependency during scaffolding
+    from sqlmodel import Session, SQLModel, create_engine
+    from sqlalchemy.engine import Engine
+except ImportError:  # pragma: no cover
+    Session = None  # type: ignore
+    SQLModel = None  # type: ignore
+    Engine = None  # type: ignore
+
+
+_engine: Engine | None = None
+
+
+def init_engine(settings: Settings | None = None) -> Engine:
+    """Initialise and cache the SQLModel engine."""
+
+    global _engine
+    if _engine is not None:
+        return _engine
+
+    settings = settings or get_settings()
+    if create_engine is None:  # type: ignore[truthy-function]
+        raise RuntimeError("sqlmodel is not installed; cannot create engine")
+
+    _engine = create_engine(settings.DB_URL, echo=False)
+    return _engine
+
+
+@contextmanager
+def get_session(settings: Settings | None = None) -> Iterator[Session]:
+    """Yield a SQLModel session using the configured engine."""
+
+    if Session is None or SQLModel is None:  # pragma: no cover - handled during runtime
+        raise RuntimeError("sqlmodel is not installed; session unavailable")
+
+    engine = init_engine(settings)
+    with Session(engine) as session:  # type: ignore[call-arg]
+        yield session

--- a/backend/tests/test_contracts.py
+++ b/backend/tests/test_contracts.py
@@ -1,0 +1,59 @@
+"""Contract tests ensuring model structures remain stable."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from backend.models import ParsedObject, SectionNode, SectionSpan, SpecItem  # noqa: E402
+
+
+def test_models_schema() -> None:
+    """Instantiate models and ensure nested defaults behave as expected."""
+
+    parsed = ParsedObject(
+        object_id="obj-1",
+        file_id="file-1",
+        kind="text",
+        text="Example",
+        page_index=0,
+        bbox=[0.0, 0.0, 10.0, 10.0],
+        order_index=1,
+        metadata={"source": "test"},
+    )
+
+    section = SectionNode(
+        section_id="root",
+        file_id="file-1",
+        number=None,
+        title="Root",
+        depth=0,
+        children=[
+            SectionNode(
+                section_id="child",
+                file_id="file-1",
+                number="1",
+                title="Child",
+                depth=1,
+                children=[],
+                span=SectionSpan(start_object="obj-1", end_object="obj-1"),
+            )
+        ],
+        span=SectionSpan(start_object="obj-1", end_object="obj-1"),
+    )
+
+    spec = SpecItem(
+        spec_id="spec-1",
+        file_id="file-1",
+        section_id="root",
+        section_number="1",
+        section_title="Root",
+        spec_text="Must support mock data",
+        confidence=0.5,
+        source_object_ids=[parsed.object_id],
+    )
+
+    assert parsed.object_id == "obj-1"
+    assert section.children[0].title == "Child"
+    assert spec.source_object_ids == ["obj-1"]

--- a/backend/tests/test_routes_mock.py
+++ b/backend/tests/test_routes_mock.py
@@ -1,0 +1,47 @@
+"""Tests covering mock route responses."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from backend.main import create_app  # noqa: E402
+
+
+client = TestClient(create_app())
+
+
+def test_routes_mock() -> None:
+    """Mock endpoints respond 200 and return expected payload shapes."""
+
+    health = client.get("/healthz")
+    assert health.status_code == 200
+    assert health.json() == {"status": "ok"}
+
+    ingest = client.post("/ingest")
+    assert ingest.status_code == 200
+    body = ingest.json()
+    assert body["status"] == "queued"
+    file_id = body["file_id"]
+
+    parsed = client.get(f"/parsed/{file_id}")
+    assert parsed.status_code == 200
+    assert isinstance(parsed.json(), list)
+
+    headers = client.get(f"/headers/{file_id}")
+    assert headers.status_code == 200
+    assert headers.json()["title"] == "Document Root"
+
+    specs = client.get(f"/specs/{file_id}")
+    assert specs.status_code == 200
+    assert len(specs.json()) >= 1
+
+    chunks = client.post(f"/chunks/{file_id}")
+    assert chunks.status_code == 200
+    assert "root" in chunks.json()
+
+    openapi = client.get("/openapi.json")
+    assert openapi.status_code == 200

--- a/backend/tests/test_system_capabilities.py
+++ b/backend/tests/test_system_capabilities.py
@@ -1,0 +1,25 @@
+"""Tests for system capability reporting."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from backend.main import create_app  # noqa: E402
+
+
+client = TestClient(create_app())
+
+
+def test_capabilities_endpoint() -> None:
+    """Detect optional tools and MinerU availability."""
+
+    response = client.get("/system/capabilities")
+    assert response.status_code == 200
+    data = response.json()
+    for key in {"tesseract", "ghostscript", "java", "mineru_importable"}:
+        assert key in data
+        assert isinstance(data[key], bool)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SimpleSpecs Phase 0</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/light.css" />
+  </head>
+  <body>
+    <main>
+      <h1>SimpleSpecs (Phase 0)</h1>
+      <section>
+        <h2>Upload</h2>
+        <p>The upload workflow will be implemented in later phases.</p>
+        <button id="upload-btn" disabled>Upload File</button>
+      </section>
+      <section>
+        <h2>Find Headers</h2>
+        <button id="headers-btn">Request Mock Headers</button>
+        <pre id="headers-output"></pre>
+      </section>
+      <section>
+        <h2>Build Sections</h2>
+        <button id="chunks-btn">Request Mock Chunks</button>
+        <pre id="chunks-output"></pre>
+      </section>
+      <section>
+        <h2>Find Specs</h2>
+        <button id="specs-btn">Request Mock Specs</button>
+        <pre id="specs-output"></pre>
+      </section>
+    </main>
+    <script type="module">
+      import { fetchJson } from "./js/api.js";
+      import { AppState } from "./js/state.js";
+
+      const state = new AppState();
+      const fileId = "demo";
+
+      document.getElementById("headers-btn").addEventListener("click", async () => {
+        const data = await fetchJson(`/headers/${fileId}`);
+        document.getElementById("headers-output").textContent = JSON.stringify(data, null, 2);
+      });
+
+      document.getElementById("chunks-btn").addEventListener("click", async () => {
+        const data = await fetchJson(`/chunks/${fileId}`, { method: "POST" });
+        document.getElementById("chunks-output").textContent = JSON.stringify(data, null, 2);
+      });
+
+      document.getElementById("specs-btn").addEventListener("click", async () => {
+        const data = await fetchJson(`/specs/${fileId}`);
+        document.getElementById("specs-output").textContent = JSON.stringify(data, null, 2);
+      });
+
+      console.log("PDF engine:", state.pdfEngine);
+    </script>
+  </body>
+</html>

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -1,0 +1,17 @@
+export async function fetchJson(url, options = {}) {
+  const response = await fetch(url, {
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    ...options,
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`Request failed (${response.status}): ${message}`);
+  }
+
+  const contentType = response.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    return response.json();
+  }
+  return response.text();
+}

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -1,0 +1,6 @@
+export class AppState {
+  constructor() {
+    this.pdfEngine = 'native';
+    this.fileId = null;
+  }
+}

--- a/run.py
+++ b/run.py
@@ -1,0 +1,22 @@
+"""Helper script to launch the SimpleSpecs backend."""
+from __future__ import annotations
+
+import argparse
+
+import uvicorn
+
+
+def main() -> int:
+    """Start backend & static frontend servers."""
+
+    parser = argparse.ArgumentParser(description="Run the SimpleSpecs API server")
+    parser.add_argument("--host", default="127.0.0.1", help="Host interface to bind")
+    parser.add_argument("--port", default=8000, type=int, help="Port to bind")
+    args = parser.parse_args()
+
+    uvicorn.run("backend.main:create_app", factory=True, host=args.host, port=args.port)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    raise SystemExit(main())

--- a/run_local.py
+++ b/run_local.py
@@ -1,0 +1,15 @@
+"""Local development runner."""
+from __future__ import annotations
+
+import uvicorn
+
+
+def main() -> int:
+    """Run backend only (dev)."""
+
+    uvicorn.run("backend.main:create_app", factory=True, host="127.0.0.1", port=8000, reload=True)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- establish configuration with PDF engine toggle and MinerU flags and expose reusable settings helpers
- add FastAPI app factory with mock routers, system capability probe, and static frontend scaffold
- provide service interfaces, SQLModel engine scaffold, and frontend/test harnesses for Phase 0

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68de849565d88324804d1031af0d993b