### PR TITLE
Implement Phase P0 scaffolding updates

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-"""FastAPI application factory for SimpleSpecs."""
+"""FastAPI application factory for SimpleSpecs Phase 0."""
 from __future__ import annotations
 
 from pathlib import Path
@@ -45,7 +45,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         """Serve the frontend index file."""
 
         index_file = FRONTEND_DIR / "index.html"
-        return FileResponse(index_file) if index_file.exists() else FileResponse("frontend/index.html")
+        if index_file.exists():
+            return FileResponse(index_file)
+        # Fall back to the relative path for environments without the directory structure.
+        return FileResponse("frontend/index.html")
 
     @app.get("/healthz", summary="Health check")
     async def healthz() -> dict[str, str]:

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -1,4 +1,4 @@
-"""LLM client protocol and adapter scaffolds."""
+"""LLM adapter protocol definitions for Phase 0."""
 from __future__ import annotations
 
 from typing import Protocol, runtime_checkable

--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -1,7 +1,7 @@
-"""PDF parser abstractions and selection logic."""
+"""PDF parser abstractions and selection logic for Phase 0."""
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Optional, Protocol
 
 from backend.config import Settings
 from backend.models import ParsedObject
@@ -28,15 +28,13 @@ class MinerUPdfParser:
         return []
 
 
-def select_pdf_parser(settings: Settings, file_path: str) -> PdfParser:
-    """Select a PDF parser based on the configured engine."""
+def select_pdf_parser(settings: Settings, file_path: str) -> Optional[PdfParser]:
+    """Select a PDF parser based on the configured engine.
 
-    engine = settings.PDF_ENGINE
-    if engine == "native":
-        return NativePdfParser()
-    if engine == "mineru":
-        return MinerUPdfParser()
-    if engine == "auto":
-        return MinerUPdfParser() if settings.MINERU_ENABLED else NativePdfParser()
+    Phase 0 does not yet provide real parser wiring, so this function returns
+    ``None`` as a placeholder regardless of configuration. Later phases will
+    supply the actual adapter selection.
+    """
 
-    raise ValueError(f"Unsupported PDF engine: {engine}")
+    _ = (settings, file_path)
+    return None

--- a/run.py
+++ b/run.py
@@ -1,9 +1,38 @@
-"""Helper script to launch the SimpleSpecs backend."""
+"""Helper script to launch the SimpleSpecs backend and static frontend server."""
 from __future__ import annotations
 
 import argparse
+import contextlib
+import threading
+from functools import partial
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+from socketserver import ThreadingMixIn
 
 import uvicorn
+
+
+FRONTEND_DIR = Path(__file__).resolve().parent / "frontend"
+
+
+class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
+    """Threaded HTTP server serving static files."""
+
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+def _start_static_server(host: str, port: int) -> tuple[threading.Thread, ThreadedHTTPServer] | tuple[None, None]:
+    """Launch a background static file server for the frontend directory."""
+
+    if not FRONTEND_DIR.exists():
+        return None, None
+
+    handler_factory = partial(SimpleHTTPRequestHandler, directory=str(FRONTEND_DIR))
+    server: ThreadedHTTPServer = ThreadedHTTPServer((host, port), handler_factory)  # type: ignore[arg-type]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return thread, server
 
 
 def main() -> int:
@@ -12,9 +41,19 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Run the SimpleSpecs API server")
     parser.add_argument("--host", default="127.0.0.1", help="Host interface to bind")
     parser.add_argument("--port", default=8000, type=int, help="Port to bind")
+    parser.add_argument("--static-port", default=8001, type=int, help="Port to serve static frontend files")
     args = parser.parse_args()
 
-    uvicorn.run("backend.main:create_app", factory=True, host=args.host, port=args.port)
+    static_thread, static_server = _start_static_server(args.host, args.static_port)
+
+    try:
+        uvicorn.run("backend.main:create_app", factory=True, host=args.host, port=args.port)
+    finally:
+        if static_server is not None:
+            with contextlib.suppress(Exception):
+                static_server.shutdown()
+        if static_thread is not None:
+            static_thread.join(timeout=1)
     return 0
 
 


### PR DESCRIPTION
## Summary
- refine the FastAPI app factory to handle the frontend index fallback while keeping routers and health checks intact
- document the LLM and PDF parser scaffolds, returning a placeholder parser selection for Phase 0
- extend the run helper to launch uvicorn alongside a lightweight static file server for the frontend

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68de86ef365483248a0685a3727737ad