### PR TITLE
Add Phase P0 architecture scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SimpleSpecs — Phase P0
 
-Phase P0 establishes the project structure, configuration contracts, and mock endpoints for the UNO-less parsing stack with an optional MinerU toggle.
+Phase P0 delivers the core FastAPI skeleton, configuration contracts, and mock endpoints for the UNO-less parsing stack with an optional MinerU toggle.
 
 ## Prerequisites
 - Python 3.12+
@@ -10,7 +10,7 @@ Phase P0 establishes the project structure, configuration contracts, and mock en
 python -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip
-pip install fastapi uvicorn sqlmodel pydantic pydantic-settings httpx
+pip install -r requirements.txt
 ```
 
 ## Running the API
@@ -18,13 +18,16 @@ pip install fastapi uvicorn sqlmodel pydantic pydantic-settings httpx
 uvicorn backend.main:create_app --factory --host 127.0.0.1 --port 8000
 ```
 
-Then open [http://127.0.0.1:8000/frontend/](http://127.0.0.1:8000/frontend/) to view the scaffolded UI.
+Then open [http://127.0.0.1:8000/](http://127.0.0.1:8000/) to view the scaffolded UI and [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs) for API documentation.
 
 ## Configuration
-Set environment variables to override defaults:
-- `PDF_ENGINE` — `native`, `mineru`, or `auto`
-- `MINERU_ENABLED` — enables MinerU integration when set to `true`
-- `MINERU_MODEL_OPTS` — JSON-encoded options for MinerU models
+Settings are loaded from environment variables (prefixed with `SIMPLS_` when desired). Key options include:
+
+- `PDF_ENGINE` — `native`, `mineru`, or `auto` (default `native`)
+- `MINERU_ENABLED` — enables MinerU integrations when true (default `false`)
+- `MINERU_MODEL_OPTS` — JSON/dict style mapping for MinerU models
+- `ALLOW_ORIGINS` — comma-separated origins for CORS (default `*`)
+- `MAX_FILE_MB` — maximum upload size (default `50`)
 
 ## Tests
 ```bash

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,39 @@
+"""Application configuration module for SimpleSpecs."""
+from functools import lru_cache
+from typing import Any, Dict, List, Literal
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Runtime settings loaded from the environment."""
+
+    model_config = SettingsConfigDict(env_prefix="SIMPLS_", extra="ignore")
+
+    OPENROUTER_API_KEY: str | None = Field(default=None)
+    LLAMACPP_URL: str = Field(default="http://localhost:8080")
+    DB_URL: str = Field(default="sqlite:///./simplespecs.db")
+    ARTIFACTS_DIR: str = Field(default="artifacts")
+    ALLOW_ORIGINS: List[str] = Field(default_factory=lambda: ["*"])
+    MAX_FILE_MB: int = Field(default=50, ge=1)
+    PDF_ENGINE: Literal["native", "mineru", "auto"] = Field(default="native")
+    MINERU_ENABLED: bool = Field(default=False)
+    MINERU_MODEL_OPTS: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("ALLOW_ORIGINS", mode="before")
+    @classmethod
+    def _ensure_list(cls, value: Any) -> List[str]:
+        """Allow comma-separated strings or iterables for origins."""
+        if value is None:
+            return ["*"]
+        if isinstance(value, str):
+            return [item.strip() for item in value.split(",") if item.strip()]
+        return list(value)
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Return a cached ``Settings`` instance."""
+
+    return Settings()

--- a/backend/logging.py
+++ b/backend/logging.py
@@ -1,0 +1,24 @@
+"""Logging utilities for SimpleSpecs."""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+
+def setup_logging(level: int = logging.INFO) -> None:
+    """Configure basic logging for the application."""
+
+    if logging.getLogger().handlers:
+        return
+
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Return a logger instance, ensuring logging is configured."""
+
+    setup_logging()
+    return logging.getLogger(name)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,49 @@
+"""FastAPI application factory for SimpleSpecs."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+
+from .config import get_settings
+from .logging import setup_logging
+from .routers.files import files_router
+from .routers.headers import headers_router
+from .routers.ingest import ingest_router
+from .routers.specs import specs_router
+from .routers.system import system_router
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application."""
+
+    setup_logging()
+    settings = get_settings()
+
+    app = FastAPI(title="SimpleSpecs", version="0.1.0")
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.ALLOW_ORIGINS,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    @app.get("/healthz")
+    def healthcheck() -> dict[str, str]:
+        return {"status": "ok"}
+
+    app.include_router(ingest_router)
+    app.include_router(files_router)
+    app.include_router(headers_router)
+    app.include_router(specs_router)
+    app.include_router(system_router)
+
+    frontend_dir = Path(__file__).resolve().parent.parent / "frontend"
+    if frontend_dir.exists():
+        app.mount("/", StaticFiles(directory=frontend_dir, html=True), name="frontend")
+
+    return app

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,54 @@
+"""Pydantic models describing core API contracts for SimpleSpecs."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class BoundingBox(BaseModel):
+    """Represents a rectangular bounding box on a page."""
+
+    x0: float = Field(ge=0)
+    y0: float = Field(ge=0)
+    x1: float = Field(ge=0)
+    y1: float = Field(ge=0)
+
+
+class ParsedObject(BaseModel):
+    """One extracted text/table/image object."""
+
+    object_id: str
+    file_id: str
+    kind: Literal["text", "table", "image"]
+    text: Optional[str] = None
+    page_index: Optional[int] = Field(default=None, ge=0)
+    bbox: Optional[BoundingBox] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class SectionNode(BaseModel):
+    """Section tree node produced during header discovery."""
+
+    section_id: str
+    title: str
+    level: int = Field(ge=0)
+    page_start: Optional[int] = Field(default=None, ge=0)
+    page_end: Optional[int] = Field(default=None, ge=0)
+    object_ids: List[str] = Field(default_factory=list)
+    children: List["SectionNode"] = Field(default_factory=list)
+
+
+class SpecItem(BaseModel):
+    """Specification item extracted from a section."""
+
+    spec_id: str
+    section_id: str
+    title: str
+    content: str
+    status: Literal["draft", "confirmed", "rejected"] = "draft"
+    confidence: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+SectionNode.model_rebuild()

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -1,0 +1,61 @@
+"""Mock file routes for Phase P0."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from fastapi import APIRouter
+
+from ..models import ParsedObject
+
+files_router = APIRouter(prefix="", tags=["files"])
+
+
+def _mock_objects(file_id: str) -> List[ParsedObject]:
+    """Return a deterministic set of parsed objects for a file."""
+
+    return [
+        ParsedObject(
+            object_id=f"{file_id}-obj-1",
+            file_id=file_id,
+            kind="text",
+            text="Sample introduction paragraph.",
+            page_index=0,
+        ),
+        ParsedObject(
+            object_id=f"{file_id}-obj-2",
+            file_id=file_id,
+            kind="table",
+            text="Table describing requirements.",
+            page_index=1,
+        ),
+    ]
+
+
+@files_router.get("/parsed/{file_id}", response_model=List[ParsedObject])
+def get_parsed_objects(file_id: str) -> List[ParsedObject]:
+    """Return mock parsed objects for the provided file ID."""
+
+    return _mock_objects(file_id)
+
+
+@files_router.post("/chunks/{file_id}")
+def get_chunks(file_id: str) -> Dict[str, List[str]]:
+    """Return a deterministic mapping of section IDs to object IDs."""
+
+    objects = _mock_objects(file_id)
+    return {
+        "section-intro": [objects[0].object_id],
+        "section-details": [obj.object_id for obj in objects[1:]],
+    }
+
+
+@files_router.get("/files/{file_id}")
+def get_file_summary(file_id: str) -> Dict[str, str | int]:
+    """Return a minimal mock summary for the file."""
+
+    objects = _mock_objects(file_id)
+    return {
+        "file_id": file_id,
+        "filename": f"{file_id}.pdf",
+        "object_count": len(objects),
+    }

--- a/backend/routers/headers.py
+++ b/backend/routers/headers.py
@@ -1,0 +1,33 @@
+"""Mock header routes for Phase P0."""
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from ..models import SectionNode
+
+headers_router = APIRouter(prefix="/headers", tags=["headers"])
+
+
+@headers_router.get("/{file_id}", response_model=SectionNode)
+def get_headers(file_id: str) -> SectionNode:
+    """Return a deterministic mock header tree for the file."""
+
+    return SectionNode(
+        section_id=f"{file_id}-root",
+        title="Document",
+        level=0,
+        children=[
+            SectionNode(
+                section_id=f"{file_id}-sec-1",
+                title="Introduction",
+                level=1,
+                object_ids=[f"{file_id}-obj-1"],
+            ),
+            SectionNode(
+                section_id=f"{file_id}-sec-2",
+                title="Details",
+                level=1,
+                object_ids=[f"{file_id}-obj-2"],
+            ),
+        ],
+    )

--- a/backend/routers/ingest.py
+++ b/backend/routers/ingest.py
@@ -1,0 +1,23 @@
+"""Mock ingest routes for Phase P0."""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter
+
+from ..config import get_settings
+
+ingest_router = APIRouter(prefix="/ingest", tags=["ingest"])
+
+
+@ingest_router.post("", summary="Queue a file for ingestion")
+def queue_ingest() -> dict[str, str]:
+    """Return a deterministic mock ingest response."""
+
+    settings = get_settings()
+    file_id = uuid.uuid5(uuid.NAMESPACE_URL, "simplespecs/mock").hex[:8]
+    return {
+        "file_id": file_id,
+        "status": "queued",
+        "pdf_engine": settings.PDF_ENGINE,
+    }

--- a/backend/routers/specs.py
+++ b/backend/routers/specs.py
@@ -1,0 +1,34 @@
+"""Mock specification routes for Phase P0."""
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter
+
+from ..models import SpecItem
+
+specs_router = APIRouter(prefix="/specs", tags=["specs"])
+
+
+@specs_router.get("/{file_id}", response_model=List[SpecItem])
+def get_spec_items(file_id: str) -> List[SpecItem]:
+    """Return deterministic mock specification items for the file."""
+
+    return [
+        SpecItem(
+            spec_id=f"{file_id}-spec-1",
+            section_id=f"{file_id}-sec-1",
+            title="Power Requirements",
+            content="System shall operate on 120V AC.",
+            status="confirmed",
+            confidence=0.95,
+        ),
+        SpecItem(
+            spec_id=f"{file_id}-spec-2",
+            section_id=f"{file_id}-sec-2",
+            title="Environmental Limits",
+            content="Operating temperature range 0-50C.",
+            status="draft",
+            confidence=0.6,
+        ),
+    ]

--- a/backend/routers/system.py
+++ b/backend/routers/system.py
@@ -1,0 +1,32 @@
+"""System capability routes for SimpleSpecs."""
+from __future__ import annotations
+
+import importlib
+import shutil
+
+from fastapi import APIRouter
+
+from ..config import get_settings
+
+system_router = APIRouter(prefix="/system", tags=["system"])
+
+
+@system_router.get("/capabilities")
+def get_capabilities() -> dict[str, bool | str]:
+    """Return mock detection information for optional tooling."""
+
+    settings = get_settings()
+    capabilities = {
+        "tesseract": shutil.which("tesseract") is not None,
+        "ghostscript": shutil.which("gs") is not None,
+        "java": shutil.which("java") is not None,
+        "mineru_importable": False,
+        "pdf_engine": settings.PDF_ENGINE,
+    }
+    try:
+        importlib.import_module("mineru")
+    except ModuleNotFoundError:
+        capabilities["mineru_importable"] = False
+    else:
+        capabilities["mineru_importable"] = True
+    return capabilities

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -1,0 +1,24 @@
+"""LLM client abstractions for SimpleSpecs (Phase P0 stubs)."""
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class LLMClient(Protocol):
+    """Protocol describing minimal LLM interaction."""
+
+    async def generate(self, prompt: str, **kwargs: Any) -> str:
+        """Generate a response for the given prompt."""
+
+
+class NullLLMClient:
+    """Stub LLM client used during early phases."""
+
+    async def generate(self, prompt: str, **kwargs: Any) -> str:
+        return "LLM functionality not implemented in Phase P0."
+
+
+def get_llm_client() -> LLMClient:
+    """Return the stub LLM client."""
+
+    return NullLLMClient()

--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -1,0 +1,29 @@
+"""PDF parser abstractions for SimpleSpecs (Phase P0 stubs)."""
+from __future__ import annotations
+
+from typing import List, Protocol
+
+from ..config import Settings, get_settings
+from ..models import ParsedObject
+
+
+class PdfParser(Protocol):
+    """Protocol describing PDF parsing behavior."""
+
+    def parse(self, file_id: str, data: bytes | None = None) -> List[ParsedObject]:
+        """Parse the provided PDF data into parsed objects."""
+
+
+class MockPdfParser:
+    """Stub parser that returns an empty result set."""
+
+    def parse(self, file_id: str, data: bytes | None = None) -> List[ParsedObject]:
+        return []
+
+
+def get_pdf_parser(settings: Settings | None = None) -> PdfParser:
+    """Return a parser implementation based on configuration."""
+
+    settings = settings or get_settings()
+    _ = settings.PDF_ENGINE  # Currently unused but validates access.
+    return MockPdfParser()

--- a/backend/store.py
+++ b/backend/store.py
@@ -1,0 +1,38 @@
+"""Database scaffolding for SimpleSpecs."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+from sqlmodel import Session, SQLModel, create_engine
+
+from .config import Settings, get_settings
+
+_ENGINE = None
+
+
+def get_engine(settings: Settings | None = None):
+    """Return a shared SQLModel engine instance."""
+
+    global _ENGINE
+    if _ENGINE is None:
+        settings = settings or get_settings()
+        _ENGINE = create_engine(settings.DB_URL, echo=False)
+        SQLModel.metadata.create_all(_ENGINE)
+    return _ENGINE
+
+
+@contextmanager
+def session_scope(settings: Settings | None = None) -> Iterator[Session]:
+    """Provide a transactional scope around a series of operations."""
+
+    engine = get_engine(settings)
+    session = Session(engine)
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/backend/tests/test_contracts.py
+++ b/backend/tests/test_contracts.py
@@ -1,0 +1,42 @@
+"""Contract tests for Pydantic models."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.models import BoundingBox, ParsedObject, SectionNode, SpecItem
+
+
+def test_models_schema() -> None:
+    bbox = BoundingBox(x0=0, y0=0, x1=10, y1=10)
+    parsed = ParsedObject(
+        object_id="file-obj-1",
+        file_id="file",
+        kind="text",
+        text="example",
+        page_index=0,
+        bbox=bbox,
+    )
+    section = SectionNode(
+        section_id="sec-root",
+        title="Root",
+        level=0,
+        children=[
+            SectionNode(section_id="sec-child", title="Child", level=1, object_ids=[parsed.object_id])
+        ],
+    )
+    spec = SpecItem(
+        spec_id="spec-1",
+        section_id=section.section_id,
+        title="Requirement",
+        content="System shall be mockable.",
+    )
+
+    assert parsed.kind == "text"
+    assert section.children[0].object_ids == [parsed.object_id]
+    assert spec.status == "draft"
+    assert parsed.model_dump()["bbox"]["x1"] == 10

--- a/backend/tests/test_routes_mock.py
+++ b/backend/tests/test_routes_mock.py
@@ -1,0 +1,44 @@
+"""Tests for mock API endpoints."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from fastapi.testclient import TestClient
+
+from backend.main import create_app
+
+client = TestClient(create_app())
+
+
+def test_routes_mock() -> None:
+    health = client.get("/healthz")
+    assert health.status_code == 200
+    assert health.json() == {"status": "ok"}
+
+    ingest = client.post("/ingest")
+    assert ingest.status_code == 200
+    ingest_payload = ingest.json()
+    assert ingest_payload["status"] == "queued"
+    assert "file_id" in ingest_payload
+
+    file_id = ingest_payload["file_id"]
+    parsed = client.get(f"/parsed/{file_id}")
+    assert parsed.status_code == 200
+    assert isinstance(parsed.json(), list)
+
+    chunks = client.post(f"/chunks/{file_id}")
+    assert chunks.status_code == 200
+    assert "section-intro" in chunks.json()
+
+    headers = client.get(f"/headers/{file_id}")
+    assert headers.status_code == 200
+    assert headers.json()["title"] == "Document"
+
+    specs = client.get(f"/specs/{file_id}")
+    assert specs.status_code == 200
+    assert len(specs.json()) >= 1

--- a/backend/tests/test_system_capabilities.py
+++ b/backend/tests/test_system_capabilities.py
@@ -1,0 +1,27 @@
+"""Tests for the system capabilities endpoint."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from fastapi.testclient import TestClient
+
+from backend.main import create_app
+
+client = TestClient(create_app())
+
+
+def test_capabilities_endpoint() -> None:
+    response = client.get("/system/capabilities")
+    assert response.status_code == 200
+    payload = response.json()
+
+    for key in {"tesseract", "ghostscript", "java", "mineru_importable", "pdf_engine"}:
+        assert key in payload
+
+    assert isinstance(payload["mineru_importable"], bool)
+    assert payload["pdf_engine"] in {"native", "mineru", "auto"}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SimpleSpecs</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css" />
+  </head>
+  <body>
+    <main>
+      <h1>SimpleSpecs</h1>
+      <p>Phase P0 mock interface. API contracts are available at <code>/docs</code>.</p>
+      <section>
+        <button id="ping">Check Health</button>
+        <pre id="output">Click the button to query <code>/healthz</code>.</pre>
+      </section>
+    </main>
+    <script src="js/state.js"></script>
+    <script src="js/api.js"></script>
+  </body>
+</html>

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -1,0 +1,16 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const button = document.getElementById("ping");
+  if (!button) {
+    return;
+  }
+
+  button.addEventListener("click", async () => {
+    try {
+      const response = await fetch("/healthz");
+      const payload = await response.json();
+      window.SimpleSpecsState.setHealth(payload);
+    } catch (error) {
+      window.SimpleSpecsState.setHealth({ error: String(error) });
+    }
+  });
+});

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -1,0 +1,18 @@
+(function () {
+  const state = {
+    lastHealth: null,
+  };
+
+  window.SimpleSpecsState = {
+    get() {
+      return state;
+    },
+    setHealth(payload) {
+      state.lastHealth = payload;
+      const output = document.getElementById("output");
+      if (output) {
+        output.textContent = JSON.stringify(payload, null, 2);
+      }
+    },
+  };
+})();

--- a/run.py
+++ b/run.py
@@ -1,61 +1,15 @@
-"""Helper script to launch the SimpleSpecs backend and static frontend server."""
+"""Entrypoint to serve the SimpleSpecs application."""
 from __future__ import annotations
-
-import argparse
-import contextlib
-import threading
-from functools import partial
-from http.server import HTTPServer, SimpleHTTPRequestHandler
-from pathlib import Path
-from socketserver import ThreadingMixIn
 
 import uvicorn
 
 
-FRONTEND_DIR = Path(__file__).resolve().parent / "frontend"
-
-
-class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
-    """Threaded HTTP server serving static files."""
-
-    allow_reuse_address = True
-    daemon_threads = True
-
-
-def _start_static_server(host: str, port: int) -> tuple[threading.Thread, ThreadedHTTPServer] | tuple[None, None]:
-    """Launch a background static file server for the frontend directory."""
-
-    if not FRONTEND_DIR.exists():
-        return None, None
-
-    handler_factory = partial(SimpleHTTPRequestHandler, directory=str(FRONTEND_DIR))
-    server: ThreadedHTTPServer = ThreadedHTTPServer((host, port), handler_factory)  # type: ignore[arg-type]
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    return thread, server
-
-
 def main() -> int:
-    """Start backend & static frontend servers."""
+    """Start the backend with uvicorn."""
 
-    parser = argparse.ArgumentParser(description="Run the SimpleSpecs API server")
-    parser.add_argument("--host", default="127.0.0.1", help="Host interface to bind")
-    parser.add_argument("--port", default=8000, type=int, help="Port to bind")
-    parser.add_argument("--static-port", default=8001, type=int, help="Port to serve static frontend files")
-    args = parser.parse_args()
-
-    static_thread, static_server = _start_static_server(args.host, args.static_port)
-
-    try:
-        uvicorn.run("backend.main:create_app", factory=True, host=args.host, port=args.port)
-    finally:
-        if static_server is not None:
-            with contextlib.suppress(Exception):
-                static_server.shutdown()
-        if static_thread is not None:
-            static_thread.join(timeout=1)
+    uvicorn.run("backend.main:create_app", factory=True, host="0.0.0.0", port=8000)
     return 0
 
 
-if __name__ == "__main__":  # pragma: no cover - script entry point
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/run_local.py
+++ b/run_local.py
@@ -1,15 +1,15 @@
-"""Local development runner."""
+"""Local development runner for SimpleSpecs."""
 from __future__ import annotations
 
 import uvicorn
 
 
 def main() -> int:
-    """Run backend only (dev)."""
+    """Run the backend for local development."""
 
     uvicorn.run("backend.main:create_app", factory=True, host="127.0.0.1", port=8000, reload=True)
     return 0
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add FastAPI application factory with centralized settings and logging
- implement mock routers, services, and models to cover ingest/files/specs/system contracts
- provide frontend scaffold, runner scripts, and tests for mock endpoints

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dea2ce1468832483766704b0f3b4d3