### PR TITLE
Ensure P0 stubs expose required symbols and capabilities

### DIFF
--- a/backend/routers/system.py
+++ b/backend/routers/system.py
@@ -16,9 +16,11 @@ def get_capabilities() -> dict[str, bool | str]:
     """Return mock detection information for optional tooling."""
 
     settings = get_settings()
+    gs_available = shutil.which("gs") is not None
     capabilities = {
         "tesseract": shutil.which("tesseract") is not None,
-        "ghostscript": shutil.which("gs") is not None,
+        "gs": gs_available,
+        "ghostscript": gs_available,
         "java": shutil.which("java") is not None,
         "mineru_importable": False,
         "pdf_engine": settings.PDF_ENGINE,
@@ -26,7 +28,7 @@ def get_capabilities() -> dict[str, bool | str]:
     try:
         importlib.import_module("mineru")
     except ModuleNotFoundError:
-        capabilities["mineru_importable"] = False
+        pass
     else:
         capabilities["mineru_importable"] = True
     return capabilities

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -1,24 +1,33 @@
 """LLM client abstractions for SimpleSpecs (Phase P0 stubs)."""
 from __future__ import annotations
 
-from typing import Any, Protocol
+from typing import Protocol
+
+__all__ = ["LLMAdapter", "OpenRouterAdapter", "LlamaCppAdapter"]
 
 
-class LLMClient(Protocol):
-    """Protocol describing minimal LLM interaction."""
+class LLMAdapter(Protocol):
+    """Protocol describing minimal synchronous LLM interaction."""
 
-    async def generate(self, prompt: str, **kwargs: Any) -> str:
+    def generate(self, prompt: str) -> str:
         """Generate a response for the given prompt."""
 
 
-class NullLLMClient:
-    """Stub LLM client used during early phases."""
+class OpenRouterAdapter:
+    """Stub adapter representing an OpenRouter-based integration."""
 
-    async def generate(self, prompt: str, **kwargs: Any) -> str:
-        return "LLM functionality not implemented in Phase P0."
+    def generate(self, prompt: str) -> str:
+        return ""
 
 
-def get_llm_client() -> LLMClient:
-    """Return the stub LLM client."""
+class LlamaCppAdapter:
+    """Stub adapter representing a local LLaMA.cpp integration."""
 
-    return NullLLMClient()
+    def generate(self, prompt: str) -> str:
+        return ""
+
+
+def get_llm_client() -> LLMAdapter:
+    """Return the default stubbed adapter."""
+
+    return OpenRouterAdapter()

--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -6,6 +6,8 @@ from typing import List, Protocol
 from ..config import Settings, get_settings
 from ..models import ParsedObject
 
+__all__ = ["PdfParser", "select_pdf_parser"]
+
 
 class PdfParser(Protocol):
     """Protocol describing PDF parsing behavior."""
@@ -21,9 +23,17 @@ class MockPdfParser:
         return []
 
 
-def get_pdf_parser(settings: Settings | None = None) -> PdfParser:
-    """Return a parser implementation based on configuration."""
+def select_pdf_parser(settings: Settings | None = None, file_path: str | None = None) -> PdfParser | None:
+    """Return the placeholder parser for Phase P0."""
 
     settings = settings or get_settings()
-    _ = settings.PDF_ENGINE  # Currently unused but validates access.
+    _ = settings.PDF_ENGINE  # Access to assert configuration availability.
     return MockPdfParser()
+
+
+def get_pdf_parser(settings: Settings | None = None) -> PdfParser:
+    """Backward-compatible accessor for the default parser."""
+
+    parser = select_pdf_parser(settings=settings)
+    assert parser is not None  # Narrow type for callers expecting a parser.
+    return parser

--- a/backend/store.py
+++ b/backend/store.py
@@ -4,11 +4,36 @@ from __future__ import annotations
 from contextlib import contextmanager
 from typing import Iterator
 
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Field, Session, SQLModel, create_engine
 
 from .config import Settings, get_settings
 
+__all__ = [
+    "DBParsedObject",
+    "DBSectionNode",
+    "DBSpecItem",
+    "get_session",
+]
+
 _ENGINE = None
+
+
+class DBParsedObject(SQLModel, table=True):
+    """Minimal SQLModel stub representing a parsed object."""
+
+    id: int | None = Field(default=None, primary_key=True)
+
+
+class DBSectionNode(SQLModel, table=True):
+    """Minimal SQLModel stub representing a section node."""
+
+    id: int | None = Field(default=None, primary_key=True)
+
+
+class DBSpecItem(SQLModel, table=True):
+    """Minimal SQLModel stub representing a specification item."""
+
+    id: int | None = Field(default=None, primary_key=True)
 
 
 def get_engine(settings: Settings | None = None):
@@ -22,12 +47,18 @@ def get_engine(settings: Settings | None = None):
     return _ENGINE
 
 
+def get_session(settings: Settings | None = None) -> Session:
+    """Return a SQLModel session bound to the configured engine."""
+
+    engine = get_engine(settings)
+    return Session(engine)
+
+
 @contextmanager
 def session_scope(settings: Settings | None = None) -> Iterator[Session]:
     """Provide a transactional scope around a series of operations."""
 
-    engine = get_engine(settings)
-    session = Session(engine)
+    session = get_session(settings)
     try:
         yield session
         session.commit()


### PR DESCRIPTION
## Summary
- add SQLModel stub entities and session accessor exports required by Phase 0 contracts
- provide Phase 0 LLM and PDF parser adapter stubs with the expected symbol names
- ensure the system capabilities endpoint returns all mandated keys while retaining legacy compatibility

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dea4b30edc8324b916719fd35a633b