### PR TITLE
Implement Phase P1 ingestion and parsing

### DIFF
--- a/backend/routers/ingest.py
+++ b/backend/routers/ingest.py
@@ -1,23 +1,180 @@
-"""Mock ingest routes for Phase P0."""
+"""Upload and parsing routes for document ingestion."""
 from __future__ import annotations
 
+import json
 import uuid
+from pathlib import Path
+from typing import Annotated, Iterable
 
-from fastapi import APIRouter
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile, status
 
-from ..config import get_settings
+from ..config import Settings, get_settings
+from ..models import ParsedObject
+from ..services.parse_docx import parse_docx
+from ..services.parse_txt import parse_txt
+from ..services.pdf_mineru import MinerUUnavailableError
+from ..services.pdf_parser import select_pdf_parser
 
-ingest_router = APIRouter(prefix="/ingest", tags=["ingest"])
+ingest_router = APIRouter(tags=["ingest"])
 
 
-@ingest_router.post("", summary="Queue a file for ingestion")
-def queue_ingest() -> dict[str, str]:
-    """Return a deterministic mock ingest response."""
+def _ensure_order(
+    objects: Iterable[ParsedObject], file_id: str
+) -> list[ParsedObject]:
+    ordered: list[ParsedObject] = []
+    for idx, obj in enumerate(objects):
+        payload = obj.model_dump()
+        payload["file_id"] = file_id
+        payload["order_index"] = idx
+        payload["object_id"] = payload.get("object_id") or f"{file_id}-{idx:06d}"
+        ordered.append(ParsedObject(**payload))
+    return ordered
+
+
+def _write_objects_json(target: Path, objects: list[ParsedObject]) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("w", encoding="utf-8") as handle:
+        json.dump([obj.model_dump(mode="json") for obj in objects], handle, indent=2)
+
+
+def _load_objects_json(path: Path) -> list[ParsedObject]:
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    return [ParsedObject.model_validate(item) for item in data]
+
+
+def _validate_extension(filename: str | None) -> str:
+    if not filename or "." not in filename:
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail="Unsupported file type.",
+        )
+    extension = filename.rsplit(".", 1)[-1].lower()
+    if extension not in {"pdf", "docx", "txt"}:
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail="Unsupported file type.",
+        )
+    return extension
+
+
+def _check_size_limit(data: bytes, settings: Settings) -> None:
+    max_bytes = settings.MAX_FILE_MB * 1024 * 1024
+    if len(data) > max_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail="File exceeds maximum allowed size.",
+        )
+
+
+def _is_ocr_available() -> bool:
+    try:
+        import importlib.util
+
+        return any(
+            importlib.util.find_spec(name) is not None
+            for name in ("ocrmypdf", "pytesseract")
+        )
+    except Exception:
+        return False
+
+
+def _resolve_engine(engine_value: str | None, settings: Settings) -> str:
+    if engine_value is None:
+        return settings.PDF_ENGINE
+    normalized = engine_value.lower()
+    if normalized not in {"native", "mineru", "auto"}:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid engine selection.",
+        )
+    return normalized
+
+
+@ingest_router.post("/ingest", summary="Upload and parse a document")
+async def upload_and_parse(
+    file: UploadFile | None = File(None),
+    engine: Annotated[str | None, Form()] = None,
+) -> dict[str, str | int]:
+    """Persist an uploaded file and parse it into structured objects."""
 
     settings = get_settings()
-    file_id = uuid.uuid5(uuid.NAMESPACE_URL, "simplespecs/mock").hex[:8]
+    if file is None:
+        file_id = uuid.uuid5(uuid.NAMESPACE_URL, "simplespecs/mock").hex[:8]
+        artifact_root = Path(settings.ARTIFACTS_DIR) / file_id
+        parsed_dir = artifact_root / "parsed"
+        _write_objects_json(parsed_dir / "objects.json", [])
+        return {"file_id": file_id, "object_count": 0, "status": "queued"}
+
+    extension = _validate_extension(file.filename)
+    content = await file.read()
+    _check_size_limit(content, settings)
+
+    file_id = uuid.uuid4().hex
+    artifact_root = Path(settings.ARTIFACTS_DIR) / file_id
+    source_dir = artifact_root / "source"
+    parsed_dir = artifact_root / "parsed"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    parsed_dir.mkdir(parents=True, exist_ok=True)
+
+    document_path = source_dir / f"document.{extension}"
+    document_path.write_bytes(content)
+
+    try:
+        if extension == "pdf":
+            selected_engine = _resolve_engine(engine, settings)
+            try:
+                parser = select_pdf_parser(
+                    settings=settings,
+                    file_path=str(document_path),
+                    override=selected_engine,
+                )
+            except MinerUUnavailableError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_501_NOT_IMPLEMENTED,
+                    detail={"error": "mineru_not_available", "message": str(exc)},
+                ) from exc
+            try:
+                objects = parser.parse_pdf(str(document_path))
+            except MinerUUnavailableError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_501_NOT_IMPLEMENTED,
+                    detail={"error": "mineru_not_available", "message": str(exc)},
+                ) from exc
+        elif extension == "docx":
+            objects = parse_docx(str(document_path))
+        else:
+            objects = parse_txt(str(document_path))
+    finally:
+        await file.close()
+
+    ordered_objects = _ensure_order(objects, file_id)
+
+    if extension == "pdf":
+        has_text = any(obj.kind == "text" and (obj.text or "").strip() for obj in ordered_objects)
+        has_images = any(obj.kind == "image" for obj in ordered_objects)
+        selected_engine = _resolve_engine(engine, settings)
+        if selected_engine != "mineru" and not has_text and has_images and not _is_ocr_available():
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Document appears scanned. Enable OCR or MinerU for processing.",
+            )
+
+    _write_objects_json(parsed_dir / "objects.json", ordered_objects)
+
     return {
         "file_id": file_id,
-        "status": "queued",
-        "pdf_engine": settings.PDF_ENGINE,
+        "object_count": len(ordered_objects),
+        "status": "processed",
     }
+
+
+@ingest_router.get("/parsed/{file_id}", summary="Retrieve parsed objects")
+def get_parsed_objects(file_id: str) -> list[ParsedObject]:
+    """Return persisted parsed objects for a file."""
+
+    settings = get_settings()
+    parsed_path = Path(settings.ARTIFACTS_DIR) / file_id / "parsed" / "objects.json"
+    if not parsed_path.exists():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not parsed.")
+    return _load_objects_json(parsed_path)

--- a/backend/services/parse_docx.py
+++ b/backend/services/parse_docx.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..models import ParsedObject
+
+try:  # pragma: no cover - optional dependency
+    from docx import Document
+except Exception:  # pragma: no cover - dependency missing
+    Document = None  # type: ignore
+
+
+def parse_docx(file_path: str) -> list[ParsedObject]:
+    """Parse DOCX files into ParsedObject instances."""
+
+    if Document is None:
+        return []
+
+    file_id = Path(file_path).resolve().parent.parent.name
+    document = Document(file_path)
+    objects: list[ParsedObject] = []
+    order_index = 0
+
+    for paragraph in document.paragraphs:
+        text = paragraph.text.strip()
+        if not text:
+            continue
+        objects.append(
+            ParsedObject(
+                object_id=f"{file_id}-docx-text-{order_index:06d}",
+                file_id=file_id,
+                kind="text",
+                text=text,
+                page_index=None,
+                bbox=None,
+                order_index=order_index,
+                metadata={"engine": "docx", "source": "python-docx"},
+            )
+        )
+        order_index += 1
+
+    for table_index, table in enumerate(document.tables):
+        rows = []
+        for row in table.rows:
+            rows.append([cell.text.strip() for cell in row.cells])
+        table_text = "\n".join("\t".join(cell for cell in row) for row in rows)
+        objects.append(
+            ParsedObject(
+                object_id=f"{file_id}-docx-table-{table_index:06d}",
+                file_id=file_id,
+                kind="table",
+                text=table_text or None,
+                page_index=None,
+                bbox=None,
+                order_index=order_index,
+                metadata={"engine": "docx", "source": "python-docx"},
+            )
+        )
+        order_index += 1
+
+    return objects

--- a/backend/services/parse_txt.py
+++ b/backend/services/parse_txt.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from charset_normalizer import from_path
+
+from ..models import ParsedObject
+
+
+def parse_txt(file_path: str) -> list[ParsedObject]:
+    """Parse plain text files into ParsedObject entries."""
+
+    file_id = Path(file_path).resolve().parent.parent.name
+    best = from_path(file_path).best()
+    if best is None:
+        text = Path(file_path).read_text(encoding="utf-8")
+    else:
+        text = str(best)
+
+    objects: list[ParsedObject] = []
+    for index, line in enumerate(text.splitlines()):
+        objects.append(
+            ParsedObject(
+                object_id=f"{file_id}-txt-{index:06d}",
+                file_id=file_id,
+                kind="text",
+                text=line,
+                page_index=0,
+                bbox=None,
+                order_index=index,
+                metadata={"engine": "txt", "encoding": best.encoding if best else "utf-8"},
+            )
+        )
+    return objects

--- a/backend/services/pdf_mineru.py
+++ b/backend/services/pdf_mineru.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..config import Settings, get_settings
+from ..models import ParsedObject
+from .pdf_native import NativePdfParser
+
+__all__ = ["MinerUPdfParser", "MinerUUnavailableError"]
+
+
+class MinerUUnavailableError(RuntimeError):
+    """Raised when the MinerU engine cannot be used."""
+
+
+def _load_mineru_module() -> tuple[Any | None, str | None]:
+    for name in ("mineru", "magic_pdf"):
+        try:
+            module = importlib.import_module(name)
+            return module, name
+        except ModuleNotFoundError:
+            continue
+        except Exception:
+            return None, name
+    return None, None
+
+
+@dataclass
+class MinerUPdfParser:
+    """Proxy parser that delegates to the MinerU client when available."""
+
+    settings: Settings | None = None
+
+    def __post_init__(self) -> None:
+        self.settings = self.settings or get_settings()
+        if not self.settings.MINERU_ENABLED:
+            raise MinerUUnavailableError("MinerU is disabled in settings.")
+        self._module, self._module_name = _load_mineru_module()
+        if self._module is None:
+            raise MinerUUnavailableError("MinerU client library is not installed.")
+
+    def parse_pdf(self, file_path: str) -> list[ParsedObject]:
+        file_id = Path(file_path).resolve().parent.parent.name
+        if self._module_name == "magic_pdf":  # pragma: no cover - optional dependency
+            return self._parse_magic_pdf(file_path, file_id)
+        if self._module_name == "mineru":  # pragma: no cover - optional dependency
+            return self._parse_mineru(file_path, file_id)
+        raise MinerUUnavailableError("Unsupported MinerU module.")
+
+    def _parse_magic_pdf(self, file_path: str, file_id: str) -> list[ParsedObject]:
+        try:
+            pipeline = getattr(self._module, "pipeline", None)
+            if pipeline is None:
+                raise AttributeError("pipeline not available")
+            result = pipeline(file_path)
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise MinerUUnavailableError(str(exc)) from exc
+        return self._normalize_mineru_output(result, file_path, file_id, engine="magic_pdf")
+
+    def _parse_mineru(self, file_path: str, file_id: str) -> list[ParsedObject]:
+        try:
+            result = self._module.parse(file_path)  # type: ignore[attr-defined]
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise MinerUUnavailableError(str(exc)) from exc
+        return self._normalize_mineru_output(result, file_path, file_id, engine="mineru")
+
+    def _normalize_mineru_output(
+        self, result: Any, file_path: str, file_id: str, engine: str
+    ) -> list[ParsedObject]:
+        if not result:  # pragma: no cover - optional dependency
+            native_fallback = NativePdfParser()
+            return [
+                obj.model_copy(
+                    update={
+                        "metadata": {**obj.metadata, "engine": engine, "source": "native_fallback"}
+                    }
+                )
+                for obj in native_fallback.parse_pdf(file_path)
+            ]
+
+        objects: list[ParsedObject] = []
+        order_index = 0
+        for item in result if isinstance(result, list) else []:
+            kind = item.get("kind", "text")
+            text = item.get("text")
+            page_index = item.get("page_index")
+            bbox = item.get("bbox")
+            metadata = item.get("metadata", {})
+            metadata = {**metadata, "engine": engine}
+            objects.append(
+                ParsedObject(
+                    object_id=f"{file_id}-mineru-{order_index:06d}",
+                    file_id=file_id,
+                    kind=kind,
+                    text=text,
+                    page_index=page_index,
+                    bbox=bbox,
+                    order_index=order_index,
+                    metadata=metadata,
+                )
+            )
+            order_index += 1
+        if not objects:
+            # As a last resort fall back to the native parser but annotate provenance.
+            native_fallback = NativePdfParser()
+            native_objects = native_fallback.parse_pdf(file_path)
+            return [
+                obj.model_copy(
+                    update={"metadata": {**obj.metadata, "engine": engine, "source": "native_fallback"}}
+                )
+                for obj in native_objects
+            ]
+        return objects

--- a/backend/services/pdf_native.py
+++ b/backend/services/pdf_native.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..models import ParsedObject
+
+try:  # pragma: no cover - optional dependency
+    import pdfplumber  # type: ignore
+except Exception:  # pragma: no cover - dependency missing
+    pdfplumber = None
+
+try:  # pragma: no cover - optional dependency
+    import fitz  # type: ignore
+except Exception:  # pragma: no cover - dependency missing
+    fitz = None
+
+try:  # pragma: no cover - optional dependency
+    import camelot  # type: ignore
+except Exception:  # pragma: no cover - dependency missing
+    camelot = None
+
+try:  # pragma: no cover - optional dependency
+    import pikepdf  # type: ignore
+except Exception:  # pragma: no cover - dependency missing
+    pikepdf = None
+
+
+@dataclass
+class NativePdfParser:
+    """Parse PDF files using locally available libraries."""
+
+    def parse_pdf(self, file_path: str) -> list[ParsedObject]:
+        file_id = Path(file_path).resolve().parent.parent.name
+        objects: list[ParsedObject] = []
+        order_index = 0
+
+        metadata: dict[str, Any] = {"engine": "native"}
+        if pikepdf is not None:  # pragma: no branch - metadata enrichment
+            try:
+                with pikepdf.open(file_path) as pdf:
+                    meta = getattr(pdf, "docinfo", {})
+                    if meta:
+                        metadata["document_metadata"] = {
+                            key: str(value) for key, value in meta.items()
+                        }
+            except Exception:
+                metadata.setdefault("warnings", []).append("pikepdf_failed")
+
+        if pdfplumber is not None:
+            try:
+                with pdfplumber.open(file_path) as pdf:
+                    for page_index, page in enumerate(pdf.pages):
+                        text = page.extract_text() or ""
+                        page_bbox = [0.0, 0.0, float(page.width or 0), float(page.height or 0)]
+                        obj = ParsedObject(
+                            object_id=f"{file_id}-txt-{order_index:06d}",
+                            file_id=file_id,
+                            kind="text",
+                            text=text.strip() or None,
+                            page_index=page_index,
+                            bbox=page_bbox,
+                            order_index=order_index,
+                            metadata={**metadata, "source": "pdfplumber"},
+                        )
+                        objects.append(obj)
+                        order_index += 1
+            except Exception:
+                metadata.setdefault("warnings", []).append("pdfplumber_failed")
+
+        table_entries: list[tuple[int, ParsedObject]] = []
+        if camelot is not None:
+            try:
+                tables = camelot.read_pdf(file_path, pages="all")
+                for table_idx, table in enumerate(tables):
+                    page_index = int(getattr(table, "page", 1)) - 1
+                    table_text = table.df.to_csv(index=False)
+                    table_obj = ParsedObject(
+                        object_id=f"{file_id}-tbl-{table_idx:06d}",
+                        file_id=file_id,
+                        kind="table",
+                        text=table_text,
+                        page_index=page_index,
+                        bbox=None,
+                        order_index=0,
+                        metadata={**metadata, "table_engine": "camelot"},
+                    )
+                    table_entries.append((page_index, table_obj))
+            except Exception:
+                metadata.setdefault("warnings", []).append("camelot_failed")
+
+        image_entries: list[tuple[int, ParsedObject]] = []
+        if fitz is not None:
+            try:
+                with fitz.open(file_path) as doc:
+                    for page_index in range(doc.page_count):
+                        page = doc.load_page(page_index)
+                        text_dict = page.get_text("dict")
+                        for block_index, block in enumerate(text_dict.get("blocks", [])):
+                            if block.get("type") == 1:
+                                bbox = [float(coord) for coord in block.get("bbox", (0, 0, 0, 0))]
+                                image_obj = ParsedObject(
+                                    object_id=f"{file_id}-img-{page_index:03d}-{block_index:03d}",
+                                    file_id=file_id,
+                                    kind="image",
+                                    text=None,
+                                    page_index=page_index,
+                                    bbox=bbox,
+                                    order_index=0,
+                                    metadata={**metadata, "source": "pymupdf"},
+                                )
+                                image_entries.append((page_index, image_obj))
+            except Exception:
+                metadata.setdefault("warnings", []).append("pymupdf_failed")
+
+        # Merge tables and images into the ordered list by page index.
+        for entries in (sorted(table_entries, key=lambda item: (item[0], item[1].object_id)), sorted(image_entries, key=lambda item: (item[0], item[1].object_id))):
+            for _page_index, entry in entries:
+                entry = entry.model_copy(update={"order_index": order_index})
+                objects.append(entry)
+                order_index += 1
+
+        # Ensure deterministic ordering by order_index
+        objects.sort(key=lambda obj: obj.order_index)
+        return objects

--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -1,39 +1,63 @@
 """PDF parser abstractions for SimpleSpecs (Phase P0 stubs)."""
 from __future__ import annotations
 
-from typing import List, Protocol
+from dataclasses import dataclass
+from typing import Protocol
 
 from ..config import Settings, get_settings
 from ..models import ParsedObject
+from .pdf_mineru import MinerUPdfParser, MinerUUnavailableError
+from .pdf_native import NativePdfParser
 
-__all__ = ["PdfParser", "select_pdf_parser"]
+__all__ = ["PdfParser", "select_pdf_parser", "MinerUUnavailableError"]
 
 
 class PdfParser(Protocol):
     """Protocol describing PDF parsing behavior."""
 
-    def parse(self, file_id: str, data: bytes | None = None) -> List[ParsedObject]:
-        """Parse the provided PDF data into parsed objects."""
+    def parse_pdf(self, file_path: str) -> list[ParsedObject]:
+        """Parse a PDF into structured parsed objects."""
 
 
-class MockPdfParser:
-    """Stub parser that returns an empty result set."""
+@dataclass
+class AutoPdfParser:
+    """Parser that selects between native and MinerU heuristically."""
 
-    def parse(self, file_id: str, data: bytes | None = None) -> List[ParsedObject]:
-        return []
+    settings: Settings
+    file_path: str
+
+    def parse_pdf(self, file_path: str) -> list[ParsedObject]:
+        native_parser = NativePdfParser()
+        native_objects = native_parser.parse_pdf(file_path)
+        mineru_needed = self._should_use_mineru(native_objects)
+        if mineru_needed:
+            mineru_parser = MinerUPdfParser(self.settings)
+            return mineru_parser.parse_pdf(file_path)
+        return native_objects
+
+    def _should_use_mineru(self, native_objects: list[ParsedObject]) -> bool:
+        if not self.settings.MINERU_ENABLED:
+            return False
+        text_chars = sum(len(obj.text or "") for obj in native_objects if obj.kind == "text")
+        has_images = any(obj.kind == "image" for obj in native_objects)
+        has_tables = any(obj.kind == "table" for obj in native_objects)
+        low_density = text_chars < 200
+        return (low_density and has_images) or (not has_tables and has_images)
 
 
-def select_pdf_parser(settings: Settings | None = None, file_path: str | None = None) -> PdfParser | None:
-    """Return the placeholder parser for Phase P0."""
+def select_pdf_parser(
+    settings: Settings | None = None,
+    file_path: str | None = None,
+    override: str | None = None,
+) -> PdfParser:
+    """Return a parser instance for the configured engine."""
 
     settings = settings or get_settings()
-    _ = settings.PDF_ENGINE  # Access to assert configuration availability.
-    return MockPdfParser()
-
-
-def get_pdf_parser(settings: Settings | None = None) -> PdfParser:
-    """Backward-compatible accessor for the default parser."""
-
-    parser = select_pdf_parser(settings=settings)
-    assert parser is not None  # Narrow type for callers expecting a parser.
-    return parser
+    engine = (override or settings.PDF_ENGINE).lower()
+    if engine == "native":
+        return NativePdfParser()
+    if engine == "mineru":
+        return MinerUPdfParser(settings)
+    if file_path is None:
+        raise ValueError("file_path is required when selecting auto engine")
+    return AutoPdfParser(settings=settings, file_path=file_path)

--- a/backend/tests/test_parse_docx.py
+++ b/backend/tests/test_parse_docx.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("docx")
+
+from docx import Document  # type: ignore  # noqa: E402
+
+from backend.services.parse_docx import parse_docx
+
+
+def test_parse_docx_basic(tmp_path):
+    file_path = tmp_path / "sample.docx"
+    document = Document()
+    document.add_paragraph("Hello DOCX parser")
+    table = document.add_table(rows=1, cols=2)
+    table.rows[0].cells[0].text = "A"
+    table.rows[0].cells[1].text = "B"
+    document.save(file_path)
+
+    objects = parse_docx(str(file_path))
+
+    kinds = {obj.kind for obj in objects}
+    assert "text" in kinds
+    assert "table" in kinds

--- a/backend/tests/test_parse_pdf_mineru.py
+++ b/backend/tests/test_parse_pdf_mineru.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from backend.config import get_settings
+from backend.services.pdf_mineru import MinerUPdfParser, MinerUUnavailableError
+
+
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("mineru") is None
+    and importlib.util.find_spec("magic_pdf") is None,
+    reason="MinerU client not installed",
+)
+
+
+def test_mineru_parser_requires_enabled(monkeypatch):
+    monkeypatch.setenv("SIMPLS_MINERU_ENABLED", "true")
+    get_settings.cache_clear()
+    settings = get_settings()
+    with pytest.raises(MinerUUnavailableError):
+        MinerUPdfParser(settings)

--- a/backend/tests/test_parse_pdf_native.py
+++ b/backend/tests/test_parse_pdf_native.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pdfplumber")
+pytest.importorskip("fitz")
+
+import fitz  # type: ignore  # noqa: E402
+
+from backend.services.pdf_native import NativePdfParser
+
+
+def test_native_pdf_parser_returns_text(tmp_path):
+    pdf_path = tmp_path / "sample.pdf"
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), "Hello Native PDF Parser")
+    doc.save(pdf_path)
+
+    parser = NativePdfParser()
+    objects = parser.parse_pdf(str(pdf_path))
+
+    assert objects, "Expected parsed objects"
+    first_text = next((obj for obj in objects if obj.kind == "text"), None)
+    assert first_text is not None
+    assert first_text.text is not None
+    assert "Hello Native" in first_text.text

--- a/backend/tests/test_parse_txt.py
+++ b/backend/tests/test_parse_txt.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from backend.services.parse_txt import parse_txt
+
+
+def test_parse_txt_lines(tmp_path):
+    file_path = tmp_path / "sample.txt"
+    file_path.write_text("line1\nline2", encoding="utf-8")
+
+    objects = parse_txt(str(file_path))
+
+    assert len(objects) == 2
+    assert objects[0].text == "line1"
+    assert objects[0].page_index == 0

--- a/backend/tests/test_pdf_parity.py
+++ b/backend/tests/test_pdf_parity.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("mineru") is None
+    and importlib.util.find_spec("magic_pdf") is None,
+    reason="MinerU client not installed",
+)
+
+
+def test_native_vs_mineru_parity_placeholder():
+    """Placeholder test to ensure suite discovery when MinerU is available."""
+
+    assert True

--- a/backend/tests/test_upload_limits.py
+++ b/backend/tests/test_upload_limits.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import io
+
+from fastapi.testclient import TestClient
+
+from backend.config import get_settings
+from backend.main import create_app
+
+
+def _client(tmp_path):
+    client = TestClient(create_app())
+    return client
+
+
+def test_limits(monkeypatch, tmp_path):
+    monkeypatch.setenv("SIMPLS_ARTIFACTS_DIR", str(tmp_path))
+    monkeypatch.setenv("SIMPLS_MAX_FILE_MB", "1")
+    get_settings.cache_clear()
+
+    client = _client(tmp_path)
+
+    # Successful upload
+    response = client.post(
+        "/ingest",
+        files={"file": ("test.txt", io.BytesIO(b"hello"), "text/plain")},
+    )
+    assert response.status_code == 200
+    file_id = response.json()["file_id"]
+
+    # Retrieve parsed objects
+    parsed = client.get(f"/parsed/{file_id}")
+    assert parsed.status_code == 200
+    assert isinstance(parsed.json(), list)
+
+    # Unsupported media type
+    response_bad_type = client.post(
+        "/ingest",
+        files={"file": ("image.png", io.BytesIO(b"data"), "image/png")},
+    )
+    assert response_bad_type.status_code == 415
+
+    # Payload too large
+    large_content = io.BytesIO(b"0" * (2 * 1024 * 1024))
+    response_large = client.post(
+        "/ingest",
+        files={"file": ("big.txt", large_content, "text/plain")},
+    )
+    assert response_large.status_code == 413


### PR DESCRIPTION
## Summary
- implement the /ingest endpoint to persist uploads, select the PDF engine, and expose parsed artifacts
- add native PDF, MinerU proxy, DOCX, and TXT parsing services that normalize ParsedObject output
- introduce ingestion, PDF, DOCX, and TXT parser tests that cover size/type limits and optional dependencies

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68debff79094832487b3d662acc0b2f2