### PR TITLE
Add ingestion integration tests for Phase 1

### DIFF
--- a/backend/tests/test_parse_docx.py
+++ b/backend/tests/test_parse_docx.py
@@ -1,25 +1,58 @@
 from __future__ import annotations
 
+import importlib.util
+from io import BytesIO
+from typing import Any
+
 import pytest
+from fastapi.testclient import TestClient
 
-pytest.importorskip("docx")
-
-from docx import Document  # type: ignore  # noqa: E402
-
-from backend.services.parse_docx import parse_docx
+from backend.main import create_app
 
 
-def test_parse_docx_basic(tmp_path):
-    file_path = tmp_path / "sample.docx"
+client = TestClient(create_app())
+DOCX_AVAILABLE = importlib.util.find_spec("docx") is not None
+
+
+def _assert_objects_shape(objects: list[dict[str, Any]]) -> None:
+    assert isinstance(objects, list) and objects, "Expected parsed objects"
+    required_keys = {"object_id", "file_id", "kind", "order_index", "metadata"}
+    for obj in objects:
+        assert required_keys.issubset(obj.keys())
+        assert isinstance(obj["metadata"], dict)
+    orders = [obj["order_index"] for obj in objects]
+    assert orders == sorted(orders)
+    assert len(set(orders)) == len(orders)
+    ordering_keys = [((obj.get("page_index") or 0), obj["order_index"]) for obj in objects]
+    assert ordering_keys == sorted(ordering_keys)
+
+
+@pytest.mark.skipif(not DOCX_AVAILABLE, reason="python-docx not installed")
+def test_parse_docx_golden() -> None:
+    from docx import Document  # type: ignore
+
     document = Document()
-    document.add_paragraph("Hello DOCX parser")
-    table = document.add_table(rows=1, cols=2)
-    table.rows[0].cells[0].text = "A"
-    table.rows[0].cells[1].text = "B"
-    document.save(file_path)
+    document.add_paragraph("Hello")
+    document.add_paragraph("World")
+    buffer = BytesIO()
+    document.save(buffer)
+    buffer.seek(0)
 
-    objects = parse_docx(str(file_path))
+    files = {
+        "file": (
+            "demo.docx",
+            buffer,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )
+    }
+    response = client.post("/ingest", files=files)
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["object_count"] >= 2
 
-    kinds = {obj.kind for obj in objects}
-    assert "text" in kinds
-    assert "table" in kinds
+    parsed = client.get(f"/parsed/{payload['file_id']}")
+    assert parsed.status_code == 200, parsed.text
+    objects = parsed.json()
+    _assert_objects_shape(objects)
+    texts = [obj.get("text") for obj in objects if obj["kind"] == "text" and obj.get("text")]
+    assert any(text and ("Hello" in text or "World" in text) for text in texts)

--- a/backend/tests/test_parse_pdf_mineru.py
+++ b/backend/tests/test_parse_pdf_mineru.py
@@ -1,23 +1,79 @@
 from __future__ import annotations
 
 import importlib.util
+from io import BytesIO
+from typing import Any
 
 import pytest
+from fastapi.testclient import TestClient
 
-from backend.config import get_settings
-from backend.services.pdf_mineru import MinerUPdfParser, MinerUUnavailableError
+from backend.main import create_app
 
 
-pytestmark = pytest.mark.skipif(
-    importlib.util.find_spec("mineru") is None
-    and importlib.util.find_spec("magic_pdf") is None,
-    reason="MinerU client not installed",
+client = TestClient(create_app())
+MINERU_AVAILABLE = any(
+    importlib.util.find_spec(name) is not None
+    for name in ("magic_pdf", "mineru", "mineru_core")
 )
 
 
-def test_mineru_parser_requires_enabled(monkeypatch):
-    monkeypatch.setenv("SIMPLS_MINERU_ENABLED", "true")
-    get_settings.cache_clear()
-    settings = get_settings()
-    with pytest.raises(MinerUUnavailableError):
-        MinerUPdfParser(settings)
+def _build_pdf_bytes() -> bytes:
+    if importlib.util.find_spec("fitz") is not None:
+        import fitz  # type: ignore
+
+        document = fitz.open()
+        page = document.new_page()
+        page.insert_text((72, 720), "Hello MinerU Parser")
+        data = document.tobytes()
+        document.close()
+        return data
+
+    if importlib.util.find_spec("reportlab.pdfgen") is not None:
+        from reportlab.pdfgen import canvas  # type: ignore
+        from reportlab.lib.pagesizes import letter  # type: ignore
+
+        buffer = BytesIO()
+        canv = canvas.Canvas(buffer, pagesize=letter)
+        canv.drawString(72, 720, "Hello MinerU Parser")
+        canv.showPage()
+        canv.save()
+        buffer.seek(0)
+        return buffer.read()
+
+    return (
+        b"%PDF-1.4\n1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj\n"
+        b"2 0 obj<< /Type /Pages /Count 1 /Kids [3 0 R] >>endobj\n"
+        b"3 0 obj<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R"
+        b" /Resources << /Font << /F1 5 0 R >> >> >>endobj\n"
+        b"4 0 obj<< /Length 55 >>stream\nBT /F1 24 Tf 72 700 Td (Hello MinerU Parser) Tj ET\nendstream\nendobj\n"
+        b"5 0 obj<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>endobj\n"
+        b"xref\n0 6\n0000000000 65535 f \n0000000010 00000 n \n0000000060 00000 n \n0000000114 00000 n \n"
+        b"0000000276 00000 n \n0000000385 00000 n \ntrailer<< /Root 1 0 R /Size 6 >>\nstartxref\n482\n%%EOF"
+    )
+
+
+def _assert_objects_shape(objects: list[dict[str, Any]]) -> None:
+    assert isinstance(objects, list) and objects, "Expected parsed objects"
+    required_keys = {"object_id", "file_id", "kind", "order_index", "metadata"}
+    for obj in objects:
+        assert required_keys.issubset(obj.keys())
+        assert isinstance(obj["metadata"], dict)
+    orders = [obj["order_index"] for obj in objects]
+    assert orders == sorted(orders)
+    assert len(set(orders)) == len(orders)
+    ordering_keys = [((obj.get("page_index") or 0), obj["order_index"]) for obj in objects]
+    assert ordering_keys == sorted(ordering_keys)
+
+
+@pytest.mark.skipif(not MINERU_AVAILABLE, reason="MinerU not importable")
+def test_pdf_mineru_golden() -> None:
+    files = {"file": ("mineru.pdf", BytesIO(_build_pdf_bytes()), "application/pdf")}
+    response = client.post("/ingest", files=files, data={"engine": "mineru"})
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["object_count"] >= 1
+
+    parsed = client.get(f"/parsed/{payload['file_id']}")
+    assert parsed.status_code == 200, parsed.text
+    objects: list[dict[str, Any]] = parsed.json()
+    _assert_objects_shape(objects)

--- a/backend/tests/test_parse_pdf_native.py
+++ b/backend/tests/test_parse_pdf_native.py
@@ -1,27 +1,80 @@
 from __future__ import annotations
 
+import importlib.util
+from io import BytesIO
+from typing import Any
+
 import pytest
+from fastapi.testclient import TestClient
 
-pytest.importorskip("pdfplumber")
-pytest.importorskip("fitz")
-
-import fitz  # type: ignore  # noqa: E402
-
-from backend.services.pdf_native import NativePdfParser
+from backend.main import create_app
 
 
-def test_native_pdf_parser_returns_text(tmp_path):
-    pdf_path = tmp_path / "sample.pdf"
-    doc = fitz.open()
-    page = doc.new_page()
-    page.insert_text((72, 72), "Hello Native PDF Parser")
-    doc.save(pdf_path)
+client = TestClient(create_app())
+PDF_READER_AVAILABLE = any(
+    importlib.util.find_spec(name) is not None for name in ("pdfplumber", "fitz")
+)
 
-    parser = NativePdfParser()
-    objects = parser.parse_pdf(str(pdf_path))
 
-    assert objects, "Expected parsed objects"
-    first_text = next((obj for obj in objects if obj.kind == "text"), None)
-    assert first_text is not None
-    assert first_text.text is not None
-    assert "Hello Native" in first_text.text
+def _build_pdf_bytes() -> bytes:
+    if importlib.util.find_spec("fitz") is not None:
+        import fitz  # type: ignore
+
+        document = fitz.open()
+        page = document.new_page()
+        page.insert_text((72, 720), "Hello Native Parser")
+        data = document.tobytes()
+        document.close()
+        return data
+
+    if importlib.util.find_spec("reportlab.pdfgen") is not None:
+        from reportlab.pdfgen import canvas  # type: ignore
+        from reportlab.lib.pagesizes import letter  # type: ignore
+
+        buffer = BytesIO()
+        canv = canvas.Canvas(buffer, pagesize=letter)
+        canv.drawString(72, 720, "Hello Native Parser")
+        canv.showPage()
+        canv.save()
+        buffer.seek(0)
+        return buffer.read()
+
+    # Fallback minimal PDF with text objects for pdfplumber when generation libs absent.
+    return (
+        b"%PDF-1.4\n1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj\n"
+        b"2 0 obj<< /Type /Pages /Count 1 /Kids [3 0 R] >>endobj\n"
+        b"3 0 obj<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R"
+        b" /Resources << /Font << /F1 5 0 R >> >> >>endobj\n"
+        b"4 0 obj<< /Length 55 >>stream\nBT /F1 24 Tf 72 700 Td (Hello Native Parser) Tj ET\nendstream\nendobj\n"
+        b"5 0 obj<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>endobj\n"
+        b"xref\n0 6\n0000000000 65535 f \n0000000010 00000 n \n0000000060 00000 n \n0000000114 00000 n \n"
+        b"0000000276 00000 n \n0000000385 00000 n \ntrailer<< /Root 1 0 R /Size 6 >>\nstartxref\n482\n%%EOF"
+    )
+
+
+def _assert_objects_shape(objects: list[dict[str, Any]]) -> None:
+    assert isinstance(objects, list) and objects, "Expected parsed objects"
+    required_keys = {"object_id", "file_id", "kind", "order_index", "metadata"}
+    for obj in objects:
+        assert required_keys.issubset(obj.keys())
+        assert isinstance(obj["metadata"], dict)
+    orders = [obj["order_index"] for obj in objects]
+    assert orders == sorted(orders)
+    assert len(set(orders)) == len(orders)
+    ordering_keys = [((obj.get("page_index") or 0), obj["order_index"]) for obj in objects]
+    assert ordering_keys == sorted(ordering_keys)
+
+
+@pytest.mark.skipif(not PDF_READER_AVAILABLE, reason="Native PDF stack not installed")
+def test_pdf_native_golden() -> None:
+    files = {"file": ("tiny.pdf", BytesIO(_build_pdf_bytes()), "application/pdf")}
+    response = client.post("/ingest", files=files, data={"engine": "native"})
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["object_count"] >= 1
+
+    parsed = client.get(f"/parsed/{payload['file_id']}")
+    assert parsed.status_code == 200, parsed.text
+    objects = parsed.json()
+    _assert_objects_shape(objects)
+    assert any(obj["kind"] == "text" for obj in objects)

--- a/backend/tests/test_parse_txt.py
+++ b/backend/tests/test_parse_txt.py
@@ -1,14 +1,47 @@
 from __future__ import annotations
 
-from backend.services.parse_txt import parse_txt
+from io import BytesIO
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from backend.main import create_app
 
 
-def test_parse_txt_lines(tmp_path):
-    file_path = tmp_path / "sample.txt"
-    file_path.write_text("line1\nline2", encoding="utf-8")
+client = TestClient(create_app())
 
-    objects = parse_txt(str(file_path))
 
-    assert len(objects) == 2
-    assert objects[0].text == "line1"
-    assert objects[0].page_index == 0
+def _assert_objects_shape(objects: list[dict[str, Any]]) -> None:
+    assert isinstance(objects, list) and objects, "Expected parsed objects"
+    required_keys = {"object_id", "file_id", "kind", "order_index", "metadata"}
+    for obj in objects:
+        assert required_keys.issubset(obj.keys())
+        assert isinstance(obj["metadata"], dict)
+    orders = [obj["order_index"] for obj in objects]
+    assert orders == sorted(orders)
+    assert len(set(orders)) == len(orders)
+    ordering_keys = [((obj.get("page_index") or 0), obj["order_index"]) for obj in objects]
+    assert ordering_keys == sorted(ordering_keys)
+
+
+def _upload_txt(lines: list[str]) -> dict[str, Any]:
+    content = "\n".join(lines).encode("utf-8")
+    files = {"file": ("note.txt", BytesIO(content), "text/plain")}
+    response = client.post("/ingest", files=files)
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert "file_id" in payload and "object_count" in payload
+    return payload
+
+
+def test_parse_txt_golden() -> None:
+    payload = _upload_txt(["alpha", "beta", "gamma"])
+    parsed = client.get(f"/parsed/{payload['file_id']}")
+    assert parsed.status_code == 200, parsed.text
+    objects = parsed.json()
+    _assert_objects_shape(objects)
+    texts = [obj.get("text") for obj in objects if obj["kind"] == "text" and obj.get("text")]
+    assert any(
+        text is not None and any(line in text for line in ("alpha", "beta", "gamma"))
+        for text in texts
+    )

--- a/backend/tests/test_pdf_parity.py
+++ b/backend/tests/test_pdf_parity.py
@@ -1,17 +1,91 @@
 from __future__ import annotations
 
 import importlib.util
+from io import BytesIO
+from typing import Any
 
 import pytest
+from fastapi.testclient import TestClient
 
-pytestmark = pytest.mark.skipif(
-    importlib.util.find_spec("mineru") is None
-    and importlib.util.find_spec("magic_pdf") is None,
-    reason="MinerU client not installed",
+from backend.main import create_app
+
+
+client = TestClient(create_app())
+MINERU_AVAILABLE = any(
+    importlib.util.find_spec(name) is not None
+    for name in ("magic_pdf", "mineru", "mineru_core")
 )
 
 
-def test_native_vs_mineru_parity_placeholder():
-    """Placeholder test to ensure suite discovery when MinerU is available."""
+def _build_pdf_bytes() -> bytes:
+    if importlib.util.find_spec("fitz") is not None:
+        import fitz  # type: ignore
 
-    assert True
+        document = fitz.open()
+        page = document.new_page()
+        page.insert_text((72, 720), "Parity Check")
+        data = document.tobytes()
+        document.close()
+        return data
+
+    if importlib.util.find_spec("reportlab.pdfgen") is not None:
+        from reportlab.pdfgen import canvas  # type: ignore
+        from reportlab.lib.pagesizes import letter  # type: ignore
+
+        buffer = BytesIO()
+        canv = canvas.Canvas(buffer, pagesize=letter)
+        canv.drawString(72, 720, "Parity Check")
+        canv.showPage()
+        canv.save()
+        buffer.seek(0)
+        return buffer.read()
+
+    return (
+        b"%PDF-1.4\n1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj\n"
+        b"2 0 obj<< /Type /Pages /Count 1 /Kids [3 0 R] >>endobj\n"
+        b"3 0 obj<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R"
+        b" /Resources << /Font << /F1 5 0 R >> >> >>endobj\n"
+        b"4 0 obj<< /Length 48 >>stream\nBT /F1 18 Tf 72 700 Td (Parity Check) Tj ET\nendstream\nendobj\n"
+        b"5 0 obj<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>endobj\n"
+        b"xref\n0 6\n0000000000 65535 f \n0000000010 00000 n \n0000000060 00000 n \n0000000114 00000 n \n"
+        b"0000000276 00000 n \n0000000385 00000 n \ntrailer<< /Root 1 0 R /Size 6 >>\nstartxref\n476\n%%EOF"
+    )
+
+
+def _collect_objects(file_id: str) -> list[dict[str, Any]]:
+    response = client.get(f"/parsed/{file_id}")
+    assert response.status_code == 200, response.text
+    objects = response.json()
+    assert isinstance(objects, list)
+    return objects
+
+
+@pytest.mark.skipif(not MINERU_AVAILABLE, reason="MinerU not importable")
+def test_native_vs_mineru_parity() -> None:
+    pdf_bytes = _build_pdf_bytes()
+    files = {"file": ("parity.pdf", BytesIO(pdf_bytes), "application/pdf")}
+
+    native_response = client.post("/ingest", files=files, data={"engine": "native"})
+    assert native_response.status_code == 200, native_response.text
+    native_payload = native_response.json()
+
+    mineru_response = client.post(
+        "/ingest",
+        files={"file": ("parity.pdf", BytesIO(pdf_bytes), "application/pdf")},
+        data={"engine": "mineru"},
+    )
+    assert mineru_response.status_code == 200, mineru_response.text
+    mineru_payload = mineru_response.json()
+
+    native_objects = _collect_objects(native_payload["file_id"])
+    mineru_objects = _collect_objects(mineru_payload["file_id"])
+
+    assert native_objects and mineru_objects
+
+    native_kinds = {obj["kind"] for obj in native_objects}
+    mineru_kinds = {obj["kind"] for obj in mineru_objects}
+    assert native_kinds & {"text", "table", "image"}
+    assert mineru_kinds & {"text", "table", "image"}
+    assert native_kinds & {"text", "table", "image"} == mineru_kinds & {"text", "table", "image"}
+
+    assert abs(len(native_objects) - len(mineru_objects)) <= max(2, len(native_objects) // 2)


### PR DESCRIPTION
## Summary
- replace the Phase 1 backend ingestion tests with API-level checks that align with the final stub names
- cover txt, docx, native PDF, and MinerU ingestion paths with shared ordering and metadata assertions
- validate engine parity when MinerU is available while gracefully skipping when dependencies are missing

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68decd2e18308324bef4544fa69f8391