### PR TITLE
Implement granular section chunking service

### DIFF
--- a/backend/services/chunker.py
+++ b/backend/services/chunker.py
@@ -1,0 +1,82 @@
+"""Granular chunking helpers for section trees."""
+from __future__ import annotations
+
+from ..models import ParsedObject, SectionNode
+
+__all__ = ["compute_section_spans"]
+
+
+def compute_section_spans(root: SectionNode, objects: list[ParsedObject]) -> dict[str, list[str]]:
+    """Return ordered object identifiers for every section in the tree.
+
+    The function enforces non-overlapping assignments across leaf sections using
+    the deterministic tie-breaker described in the phase plan. Parent sections
+    receive the ordered concatenation of their descendant leaf chunks.
+    """
+
+    ordered_objects = list(objects)
+    object_index: dict[str, int] = {obj.object_id: idx for idx, obj in enumerate(ordered_objects)}
+
+    leaf_nodes: list[SectionNode] = []
+    all_nodes: list[SectionNode] = []
+
+    def _collect(node: SectionNode) -> None:
+        all_nodes.append(node)
+        if not node.children:
+            leaf_nodes.append(node)
+        for child in node.children:
+            _collect(child)
+
+    _collect(root)
+
+    leaf_ranges: dict[str, tuple[int, int]] = {}
+    for leaf in leaf_nodes:
+        start_id = leaf.span.start_object
+        end_id = leaf.span.end_object
+        if start_id is None or end_id is None:
+            continue
+        start_index = object_index.get(start_id)
+        end_index = object_index.get(end_id)
+        if start_index is None or end_index is None:
+            continue
+        low, high = sorted((start_index, end_index))
+        leaf_ranges[leaf.section_id] = (low, high)
+
+    leaf_chunks: dict[str, list[str]] = {leaf.section_id: [] for leaf in leaf_nodes}
+
+    for index, obj in enumerate(ordered_objects):
+        candidates: list[tuple[int, int, str, SectionNode]] = []
+        for leaf in leaf_nodes:
+            span = leaf_ranges.get(leaf.section_id)
+            if span is None:
+                continue
+            start_idx, end_idx = span
+            if index < start_idx or index > end_idx:
+                continue
+            distance = index - start_idx
+            candidates.append((distance, leaf.depth, leaf.section_id, leaf))
+        if not candidates:
+            continue
+        _, _, _, chosen_leaf = min(candidates, key=lambda item: (item[0], item[1], item[2]))
+        leaf_chunks[chosen_leaf.section_id].append(obj.object_id)
+
+    result: dict[str, list[str]] = {}
+
+    def _build(node: SectionNode) -> list[str]:
+        if not node.children:
+            chunk = list(leaf_chunks.get(node.section_id, []))
+            result[node.section_id] = chunk
+            return list(chunk)
+        aggregate: list[str] = []
+        for child in node.children:
+            aggregate.extend(_build(child))
+        chunk_copy = list(aggregate)
+        result[node.section_id] = chunk_copy
+        return aggregate
+
+    _build(root)
+
+    for node in all_nodes:
+        result.setdefault(node.section_id, [])
+
+    return result

--- a/backend/tests/test_chunker.py
+++ b/backend/tests/test_chunker.py
@@ -1,0 +1,117 @@
+"""Unit tests for the chunking helpers."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.models import ParsedObject, SectionNode, SectionSpan
+from backend.services.chunker import compute_section_spans
+
+
+def _make_object(file_id: str, index: int, text: str) -> ParsedObject:
+    return ParsedObject(
+        object_id=f"{file_id}-obj-{index}",
+        file_id=file_id,
+        kind="text",
+        text=text,
+        page_index=0,
+        bbox=None,
+        order_index=index,
+    )
+
+
+def test_compute_section_spans() -> None:
+    """Objects are deterministically partitioned across section leaves."""
+
+    file_id = "file"
+    objects = [
+        _make_object(file_id, 0, "Heading"),
+        _make_object(file_id, 1, "Details 1"),
+        _make_object(file_id, 2, "Details 2"),
+        _make_object(file_id, 3, "Details 3"),
+        _make_object(file_id, 4, "Details 4"),
+    ]
+
+    section_alpha = SectionNode(
+        section_id="sec-alpha",
+        file_id=file_id,
+        title="Alpha",
+        depth=1,
+        children=[],
+        span=SectionSpan(
+            start_object=objects[0].object_id,
+            end_object=objects[1].object_id,
+        ),
+    )
+    section_beta = SectionNode(
+        section_id="sec-beta",
+        file_id=file_id,
+        title="Beta",
+        depth=2,
+        children=[],
+        span=SectionSpan(
+            start_object=objects[0].object_id,
+            end_object=objects[4].object_id,
+        ),
+    )
+    section_delta = SectionNode(
+        section_id="sec-delta",
+        file_id=file_id,
+        title="Delta",
+        depth=2,
+        children=[],
+        span=SectionSpan(
+            start_object=objects[2].object_id,
+            end_object=objects[4].object_id,
+        ),
+    )
+    section_gamma = SectionNode(
+        section_id="sec-gamma",
+        file_id=file_id,
+        title="Gamma",
+        depth=1,
+        children=[],
+        span=SectionSpan(
+            start_object=objects[0].object_id,
+            end_object=objects[4].object_id,
+        ),
+    )
+    section_parent = SectionNode(
+        section_id="sec-parent",
+        file_id=file_id,
+        title="Parent",
+        depth=1,
+        children=[section_beta, section_delta],
+    )
+    root = SectionNode(
+        section_id="root",
+        file_id=file_id,
+        title="Document",
+        depth=0,
+        children=[section_alpha, section_gamma, section_parent],
+    )
+
+    mapping = compute_section_spans(root, objects)
+
+    assert mapping["sec-alpha"] == [objects[0].object_id, objects[1].object_id]
+    assert mapping["sec-delta"] == [
+        objects[2].object_id,
+        objects[3].object_id,
+        objects[4].object_id,
+    ]
+    assert mapping["sec-gamma"] == []
+    assert mapping["sec-beta"] == []
+    assert mapping["sec-parent"] == mapping["sec-delta"]
+    assert mapping["root"] == [obj.object_id for obj in objects]
+    assert set(mapping.keys()) == {
+        "root",
+        "sec-alpha",
+        "sec-beta",
+        "sec-delta",
+        "sec-gamma",
+        "sec-parent",
+    }

--- a/backend/tests/test_parent_aggregation.py
+++ b/backend/tests/test_parent_aggregation.py
@@ -1,0 +1,92 @@
+"""Integration-style tests for parent aggregation logic."""
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Iterator
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.config import get_settings
+from backend.main import create_app
+from backend.models import ParsedObject, SectionNode
+from backend.services.chunker import compute_section_spans
+
+
+def _iter_nodes(node: SectionNode) -> Iterator[SectionNode]:
+    yield node
+    for child in node.children:
+        yield from _iter_nodes(child)
+
+
+def _iter_leaf_ids(node: SectionNode) -> list[str]:
+    if not node.children:
+        return [node.section_id]
+    result: list[str] = []
+    for child in node.children:
+        result.extend(_iter_leaf_ids(child))
+    return result
+
+
+def test_parent_equals_union() -> None:
+    """Parent text is union of children."""
+
+    app = create_app()
+    with TestClient(app) as client:
+        content = (
+            "1. Introduction\n"
+            "Intro text line.\n"
+            "1.1 Background\n"
+            "Background line.\n"
+            "2. Methods\n"
+            "Methods text.\n"
+            "3. Results\n"
+            "Results text.\n"
+        )
+        response = client.post(
+            "/ingest",
+            files={"file": ("sample.txt", content.encode("utf-8"), "text/plain")},
+        )
+        assert response.status_code == 200
+        file_id = response.json()["file_id"]
+
+        headers_response = client.post(f"/headers/{file_id}/find")
+        assert headers_response.status_code == 200
+        root = SectionNode.model_validate(headers_response.json())
+
+    settings = get_settings()
+    artifact_root = Path(settings.ARTIFACTS_DIR) / file_id
+    objects_path = artifact_root / "parsed" / "objects.json"
+
+    try:
+        with objects_path.open("r", encoding="utf-8") as handle:
+            raw_objects = json.load(handle)
+        objects = [ParsedObject.model_validate(item) for item in raw_objects]
+
+        mapping = compute_section_spans(root, objects)
+        mapping_again = compute_section_spans(root, objects)
+        assert mapping == mapping_again
+
+        for node in _iter_nodes(root):
+            assert node.section_id in mapping
+
+        leaf_ids = _iter_leaf_ids(root)
+        assigned_objects: list[str] = []
+        for leaf_id in leaf_ids:
+            assigned_objects.extend(mapping[leaf_id])
+        assert len(assigned_objects) == len(set(assigned_objects))
+
+        for node in _iter_nodes(root):
+            descendant_leaf_ids = _iter_leaf_ids(node)
+            expected: list[str] = []
+            for leaf_id in descendant_leaf_ids:
+                expected.extend(mapping[leaf_id])
+            assert mapping[node.section_id] == expected
+    finally:
+        shutil.rmtree(artifact_root, ignore_errors=True)


### PR DESCRIPTION
## Summary
- add a chunker service that assigns parsed objects to section leaves deterministically and builds parent aggregates
- add unit and integration tests covering exclusivity, ordering, and determinism with the existing ingest and headers pipeline

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df018d5acc83249f74aa66bee046e7