### PR TITLE
Implement section chunking persistence

### DIFF
--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -1,75 +1,30 @@
-"""Mock file routes for Phase P0."""
+"""File-related routes that complement ingestion."""
 from __future__ import annotations
 
-from typing import Dict, List, Literal, Tuple
+from fastapi import APIRouter, HTTPException, status
 
-from fastapi import APIRouter
-
-from ..models import ParsedObject
+from ..services.chunker import load_persisted_chunks, run_chunking
 
 files_router = APIRouter(prefix="", tags=["files"])
 
 
-def _mock_objects(file_id: str) -> List[ParsedObject]:
-    """Return a deterministic set of parsed objects for a file."""
+@files_router.post("/chunks/{file_id}", response_model=dict[str, list[str]])
+def create_chunks(file_id: str) -> dict[str, list[str]]:
+    """Compute and persist section chunks for the provided file."""
 
-    objects: List[ParsedObject] = []
-    samples: List[Tuple[Literal["text", "table", "image"], str, int, List[float]]] = [
-        (
-            "text",
-            "Sample introduction paragraph.",
-            0,
-            [12.0, 48.0, 580.0, 680.0],
-        ),
-        (
-            "table",
-            "Table describing requirements.",
-            1,
-            [36.0, 120.0, 560.0, 420.0],
-        ),
-    ]
-
-    for order, (kind, text, page_index, bbox) in enumerate(samples):
-        objects.append(
-            ParsedObject(
-                object_id=f"{file_id}-obj-{order + 1}",
-                file_id=file_id,
-                kind=kind,
-                text=text,
-                page_index=page_index,
-                bbox=bbox,
-                order_index=order,
-            )
-        )
-
-    return objects
+    try:
+        return run_chunking(file_id)
+    except FileNotFoundError as exc:
+        detail = str(exc) or "Required artifacts missing."
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail) from exc
 
 
-@files_router.get("/parsed/{file_id}", response_model=List[ParsedObject])
-def get_parsed_objects(file_id: str) -> List[ParsedObject]:
-    """Return mock parsed objects for the provided file ID."""
+@files_router.get("/chunks/{file_id}", response_model=dict[str, list[str]])
+def get_chunks(file_id: str) -> dict[str, list[str]]:
+    """Return persisted section chunks for the provided file."""
 
-    return _mock_objects(file_id)
-
-
-@files_router.post("/chunks/{file_id}")
-def get_chunks(file_id: str) -> Dict[str, List[str]]:
-    """Return a deterministic mapping of section IDs to object IDs."""
-
-    objects = _mock_objects(file_id)
-    return {
-        "section-intro": [objects[0].object_id],
-        "section-details": [obj.object_id for obj in objects[1:]],
-    }
-
-
-@files_router.get("/files/{file_id}")
-def get_file_summary(file_id: str) -> Dict[str, str | int]:
-    """Return a minimal mock summary for the file."""
-
-    objects = _mock_objects(file_id)
-    return {
-        "file_id": file_id,
-        "filename": f"{file_id}.pdf",
-        "object_count": len(objects),
-    }
+    try:
+        return load_persisted_chunks(file_id)
+    except FileNotFoundError as exc:
+        detail = str(exc) or "Chunks not found."
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail) from exc

--- a/backend/tests/test_routes_mock.py
+++ b/backend/tests/test_routes_mock.py
@@ -1,6 +1,7 @@
 """Tests for mock API endpoints."""
 from __future__ import annotations
 
+from io import BytesIO
 import sys
 from pathlib import Path
 
@@ -20,24 +21,42 @@ def test_routes_mock() -> None:
     assert health.status_code == 200
     assert health.json() == {"status": "ok"}
 
-    ingest = client.post("/ingest")
+    content = (
+        "1. Introduction\n"
+        "Intro line one.\n"
+        "1.1 Scope\n"
+        "Scope details.\n"
+        "2. Details\n"
+        "Detail line.\n"
+    ).encode("utf-8")
+    ingest = client.post(
+        "/ingest",
+        files={"file": ("sample.txt", BytesIO(content), "text/plain")},
+    )
     assert ingest.status_code == 200
     ingest_payload = ingest.json()
-    assert ingest_payload["status"] == "queued"
+    assert ingest_payload["status"] == "processed"
     assert "file_id" in ingest_payload
 
     file_id = ingest_payload["file_id"]
     parsed = client.get(f"/parsed/{file_id}")
     assert parsed.status_code == 200
-    assert isinstance(parsed.json(), list)
+    assert isinstance(parsed.json(), list) and parsed.json()
+
+    headers = client.post(f"/headers/{file_id}/find")
+    assert headers.status_code == 200
+    header_payload = headers.json()
+    assert header_payload["title"] == "Document"
 
     chunks = client.post(f"/chunks/{file_id}")
     assert chunks.status_code == 200
-    assert "section-intro" in chunks.json()
+    chunk_payload = chunks.json()
+    assert chunk_payload
+    assert header_payload["section_id"] in chunk_payload
 
-    headers = client.get(f"/headers/{file_id}")
-    assert headers.status_code == 200
-    assert headers.json()["title"] == "Document"
+    persisted_chunks = client.get(f"/chunks/{file_id}")
+    assert persisted_chunks.status_code == 200
+    assert persisted_chunks.json() == chunk_payload
 
     specs = client.get(f"/specs/{file_id}")
     assert specs.status_code == 200


### PR DESCRIPTION
## Summary
- add chunking service helpers to load parsed data, compute section mappings, and persist artifacts
- replace the mock chunk routes with endpoints that create and serve persisted chunk maps
- update the smoke test to exercise the ingest → headers → chunks pipeline end to end

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df048a5f70832496007c5c9286acc1