### PR TITLE
Implement Phase P4 spec extraction loop

### DIFF
--- a/backend/routers/specs.py
+++ b/backend/routers/specs.py
@@ -1,38 +1,119 @@
-"""Mock specification routes for Phase P0."""
+"""Specification extraction routes."""
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import List
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, Query, status
 
-from ..models import SpecItem
+from ..config import get_settings
+from ..models import ParsedObject, SectionNode, SpecItem
+from ..services.llm_client import LlamaCppAdapter, OpenRouterAdapter
+from ..services.specs import extract_specs_for_sections
 
 specs_router = APIRouter(prefix="/specs", tags=["specs"])
 
 
+def _load_parsed_objects(file_id: str) -> list[ParsedObject]:
+    settings = get_settings()
+    target = Path(settings.ARTIFACTS_DIR) / file_id / "parsed" / "objects.json"
+    if not target.exists():
+        raise FileNotFoundError("parsed_missing")
+    with target.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    return [ParsedObject.model_validate(item) for item in data]
+
+
+def _load_sections(file_id: str) -> SectionNode:
+    settings = get_settings()
+    target = Path(settings.ARTIFACTS_DIR) / file_id / "headers" / "sections.json"
+    if not target.exists():
+        raise FileNotFoundError("sections_missing")
+    with target.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    return SectionNode.model_validate(data)
+
+
+def _load_persisted_specs(file_id: str) -> list[SpecItem]:
+    settings = get_settings()
+    target = Path(settings.ARTIFACTS_DIR) / file_id / "specs" / "specs.json"
+    if not target.exists():
+        raise FileNotFoundError("specs_missing")
+    with target.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    return [SpecItem.model_validate(item) for item in payload]
+
+
+def _select_adapter(name: str | None):
+    if name is None or name.lower() == "openrouter":
+        return OpenRouterAdapter()
+    if name.lower() == "llamacpp":
+        return LlamaCppAdapter()
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="Unsupported llm adapter.",
+    )
+
+
+@specs_router.post("/{file_id}/find", response_model=List[SpecItem])
+def find_spec_items(file_id: str, llm: str | None = Query(default=None)) -> List[SpecItem]:
+    """Run spec extraction for the requested file and persist results."""
+
+    adapter = _select_adapter(llm)
+    try:
+        objects = _load_parsed_objects(file_id)
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Parsed objects not found.",
+        ) from exc
+    try:
+        sections = _load_sections(file_id)
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Header sections not found. Run phase 2.",
+        ) from exc
+    try:
+        return extract_specs_for_sections(file_id, sections, objects, adapter)
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Section chunks not found. Run phase 3.",
+        ) from exc
+
+
 @specs_router.get("/{file_id}", response_model=List[SpecItem])
 def get_spec_items(file_id: str) -> List[SpecItem]:
-    """Return deterministic mock specification items for the file."""
+    """Return persisted specification items for the file."""
 
-    return [
-        SpecItem(
-            spec_id=f"{file_id}-spec-1",
-            file_id=file_id,
-            section_id=f"{file_id}-sec-1",
-            section_number="1",
-            section_title="Power Requirements",
-            spec_text="System shall operate on 120V AC.",
-            confidence=0.95,
-            source_object_ids=[f"{file_id}-obj-1"],
-        ),
-        SpecItem(
-            spec_id=f"{file_id}-spec-2",
-            file_id=file_id,
-            section_id=f"{file_id}-sec-2",
-            section_number="2",
-            section_title="Environmental Limits",
-            spec_text="Operating temperature range 0-50C.",
-            confidence=0.6,
-            source_object_ids=[f"{file_id}-obj-2"],
-        ),
-    ]
+    try:
+        return _load_persisted_specs(file_id)
+    except FileNotFoundError:
+        pass
+
+    try:
+        objects = _load_parsed_objects(file_id)
+        sections = _load_sections(file_id)
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Specs not found.",
+        ) from exc
+
+    try:
+        extract_specs_for_sections(file_id, sections, objects, OpenRouterAdapter())
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Specs not found.",
+        ) from exc
+
+    try:
+        return _load_persisted_specs(file_id)
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Specs not found.",
+        ) from exc

--- a/backend/services/specs.py
+++ b/backend/services/specs.py
@@ -1,0 +1,229 @@
+"""Specification extraction loop for phase P4."""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Iterable
+
+from ..config import Settings, get_settings
+from ..models import ParsedObject, SectionNode, SpecItem
+from .llm_client import LLMAdapter
+
+__all__ = ["build_specs_prompt", "extract_specs_for_sections"]
+
+_MAX_SECTION_TEXT = 10_000
+_UNIT_PATTERN = re.compile(
+    r"\b\d+(?:\.\d+)?\s?(?:mm|cm|m|in|ft|N|kN|MPa|GPa|°C|°F)\b",
+    re.IGNORECASE,
+)
+_STANDARD_PATTERN = re.compile(r"\b(?:ASME|ISO|DIN|ASTM)\b", re.IGNORECASE)
+_BULLET_PATTERN = re.compile(r"^\s*(?:[-\u2022*]|\d+(?:\.\d+)*[.)]?)")
+
+
+def _load_chunks(file_id: str, settings: Settings) -> dict[str, list[str]]:
+    target = Path(settings.ARTIFACTS_DIR) / file_id / "chunks" / "chunks.json"
+    if not target.exists():
+        raise FileNotFoundError("chunks_missing")
+    with target.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    return {key: list(value) for key, value in data.items()}
+
+
+def _persist_specs(file_id: str, specs: Iterable[SpecItem], settings: Settings) -> None:
+    base = Path(settings.ARTIFACTS_DIR) / file_id / "specs"
+    base.mkdir(parents=True, exist_ok=True)
+    payload = [item.model_dump(mode="json") for item in specs]
+    with (base / "specs.json").open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+
+
+def _iter_leaves(root: SectionNode) -> Iterable[SectionNode]:
+    if not root.children:
+        yield root
+        return
+    for child in root.children:
+        yield from _iter_leaves(child)
+
+
+def _sorted_objects(objects: Iterable[ParsedObject]) -> list[ParsedObject]:
+    return sorted(objects, key=lambda obj: ((obj.page_index or 0), obj.order_index))
+
+
+def _normalize_line(line: str) -> str:
+    text = line.strip()
+    if not text:
+        return ""
+    text = re.sub(r"^[-\u2022*]\s+", "", text)
+    text = re.sub(r"^\d+(?:\.\d+)*[.)]\s*", "", text)
+    text = re.sub(r"^\d+(?:\.\d+)*\s+", "", text)
+    while text and text[-1] in ".;:,":
+        text = text[:-1]
+    return text.strip()
+
+
+def _parse_llm_response(payload: str) -> list[str]:
+    lines: list[str] = []
+    for raw in payload.splitlines():
+        cleaned = _normalize_line(raw)
+        if cleaned:
+            lines.append(cleaned)
+    return lines
+
+
+def _fallback_candidates(section_text: str) -> list[str]:
+    matches: list[str] = []
+    for raw in section_text.splitlines():
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        if (
+            _UNIT_PATTERN.search(stripped)
+            or _STANDARD_PATTERN.search(stripped)
+            or _BULLET_PATTERN.match(stripped)
+        ):
+            normalized = _normalize_line(stripped)
+            if normalized:
+                matches.append(normalized)
+        if len(matches) >= 5:
+            break
+    return matches
+
+
+
+
+def _find_heading_index(section: SectionNode, objects: list[ParsedObject]) -> int | None:
+    target = _normalize_line(section.title).lower()
+    if not target:
+        return None
+    for idx, obj in enumerate(objects):
+        content = (obj.text or "").strip()
+        if not content:
+            continue
+        normalized = _normalize_line(content).lower()
+        if normalized == target:
+            return idx
+    return None
+
+
+def _build_fallback_mapping(
+    leaves: list[SectionNode],
+    chunk_map: dict[str, list[str]],
+    ordered_objects: list[ParsedObject],
+    order_index: dict[str, int],
+) -> dict[str, list[str]]:
+    start_positions: list[tuple[str, int, bool]] = []
+    for section in leaves:
+        object_ids = [oid for oid in chunk_map.get(section.section_id, []) if oid in order_index]
+        if object_ids:
+            start_positions.append((section.section_id, order_index[object_ids[0]], True))
+            continue
+        heading_idx = _find_heading_index(section, ordered_objects)
+        if heading_idx is not None:
+            start_positions.append((section.section_id, heading_idx, False))
+    start_positions.sort(key=lambda item: item[1])
+    fallback: dict[str, list[str]] = {}
+    for idx, (section_id, start_idx, has_chunk) in enumerate(start_positions):
+        if has_chunk:
+            continue
+        end_idx = len(ordered_objects) - 1
+        for _, next_start, _ in start_positions[idx + 1 :]:
+            if next_start > start_idx:
+                end_idx = next_start - 1
+                break
+        if end_idx < start_idx:
+            end_idx = start_idx
+        fallback[section_id] = [
+            ordered_objects[pos].object_id for pos in range(start_idx, end_idx + 1)
+        ]
+    if not fallback:
+        has_chunks = any(chunk_map.get(section.section_id) for section in leaves)
+        if not has_chunks and leaves:
+            fallback[leaves[0].section_id] = [obj.object_id for obj in ordered_objects]
+    return fallback
+def build_specs_prompt(section: SectionNode, text: str) -> str:
+    """Construct the deterministic prompt for a section."""
+
+    section_number = section.number or "N/A"
+    truncated_text = text[:_MAX_SECTION_TEXT]
+    return (
+        "You are extracting mechanical engineering specifications.\n"
+        f'Section: "{section.title}" (Number: {section_number})\n'
+        "Provide a concise bullet list of each mechanical engineering specification found in this section.\n"
+        "Return each spec on its own line; do not include commentary.\n\n"
+        f"{truncated_text}"
+    )
+
+
+def extract_specs_for_sections(
+    file_id: str,
+    root: SectionNode,
+    objects: list[ParsedObject],
+    adapter: LLMAdapter,
+    settings: Settings | None = None,
+) -> list[SpecItem]:
+    """Iterate document leaves, run the adapter, and persist specs."""
+
+    settings = settings or get_settings()
+    chunk_map = _load_chunks(file_id, settings)
+    indexed_objects = {obj.object_id: obj for obj in objects}
+    ordered_objects = _sorted_objects(objects)
+    order_index = {obj.object_id: idx for idx, obj in enumerate(ordered_objects)}
+
+    specs: list[SpecItem] = []
+
+    leaves = list(_iter_leaves(root))
+    fallback_map = _build_fallback_mapping(leaves, chunk_map, ordered_objects, order_index)
+
+    for section in leaves:
+        object_ids = chunk_map.get(section.section_id, [])
+        if not object_ids:
+            object_ids = fallback_map.get(section.section_id, [])
+        if not object_ids:
+            continue
+        sorted_ids = sorted(
+            [oid for oid in object_ids if oid in indexed_objects],
+            key=lambda oid: order_index[oid],
+        )
+        if not sorted_ids:
+            continue
+        section_lines: list[str] = []
+        for object_id in sorted_ids:
+            obj = indexed_objects[object_id]
+            if obj.kind != "text":
+                continue
+            text = (obj.text or "").strip()
+            if text:
+                section_lines.append(text)
+        if not section_lines:
+            continue
+        section_text = "\n".join(section_lines)
+        prompt = build_specs_prompt(section, section_text)
+        try:
+            response = adapter.generate(prompt)
+        except Exception:
+            response = ""
+        response_lines = _parse_llm_response(response) if response.strip() else []
+        candidates = response_lines or _fallback_candidates(section_text)
+        for index, candidate in enumerate(candidates):
+            spec_text = candidate
+            if not spec_text:
+                continue
+            spec_id_seed = f"{file_id}|{section.section_id}|{index}|{spec_text}"
+            spec_id = hashlib.sha1(spec_id_seed.encode("utf-8")).hexdigest()
+            specs.append(
+                SpecItem(
+                    spec_id=spec_id,
+                    file_id=file_id,
+                    section_id=section.section_id,
+                    section_number=section.number,
+                    section_title=section.title,
+                    spec_text=spec_text,
+                    confidence=None,
+                    source_object_ids=list(sorted_ids),
+                )
+            )
+
+    _persist_specs(file_id, specs, settings)
+    return specs

--- a/backend/tests/test_specs_loop_resume.py
+++ b/backend/tests/test_specs_loop_resume.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from io import BytesIO
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.config import get_settings  # noqa: E402
+from backend.main import create_app  # noqa: E402
+
+
+def _hash_payload(payload: list[dict[str, object]]) -> str:
+    serialized = json.dumps(payload, sort_keys=True)
+    return hashlib.sha1(serialized.encode("utf-8")).hexdigest()
+
+
+def test_resume_on_failure(tmp_path, monkeypatch) -> None:
+    """Spec extraction endpoints persist deterministic results across adapters."""
+
+    artifacts_dir = tmp_path / "artifacts"
+    monkeypatch.setenv("SIMPLS_ARTIFACTS_DIR", str(artifacts_dir))
+    get_settings.cache_clear()
+    client = TestClient(create_app())
+
+    content = (
+        "1. Introduction\n"
+        "Overview of the system.\n"
+        "1.1 Background\n"
+        "- The actuator shall withstand 500 N axial load.\n"
+        "2. Methods\n"
+        "- Operating temperature range 0 to 60 °C.\n"
+        "3. Results\n"
+        "Materials shall comply with ISO 2768.\n"
+    ).encode("utf-8")
+
+    ingest = client.post(
+        "/ingest",
+        files={"file": ("specs.txt", BytesIO(content), "text/plain")},
+    )
+    assert ingest.status_code == 200
+    file_id = ingest.json()["file_id"]
+
+    headers = client.post(f"/headers/{file_id}/find")
+    assert headers.status_code == 200
+
+    chunk_response = client.post(f"/chunks/{file_id}")
+    assert chunk_response.status_code == 200
+    chunk_map = chunk_response.json()
+
+    first = client.post(f"/specs/{file_id}/find", params={"llm": "openrouter"})
+    assert first.status_code == 200
+    first_specs = first.json()
+    assert isinstance(first_specs, list)
+    assert first_specs
+
+    repeat = client.post(f"/specs/{file_id}/find", params={"llm": "openrouter"})
+    assert repeat.status_code == 200
+    second_specs = repeat.json()
+    assert _hash_payload(second_specs) == _hash_payload(first_specs)
+
+    llama = client.post(f"/specs/{file_id}/find", params={"llm": "llamacpp"})
+    assert llama.status_code == 200
+    llama_specs = llama.json()
+    assert llama_specs == first_specs
+
+    persisted = client.get(f"/specs/{file_id}")
+    assert persisted.status_code == 200
+    assert persisted.json() == first_specs
+
+    for item in first_specs:
+        assert set(item.keys()) == {
+            "spec_id",
+            "file_id",
+            "section_id",
+            "section_number",
+            "section_title",
+            "spec_text",
+            "confidence",
+            "source_object_ids",
+        }
+        assert item["source_object_ids"] == chunk_map[item["section_id"]]
+        assert item["file_id"] == file_id
+        assert item["spec_text"].strip() == item["spec_text"]
+
+    get_settings.cache_clear()

--- a/frontend/js/ui-specs.js
+++ b/frontend/js/ui-specs.js
@@ -1,0 +1,8 @@
+export function initSpecs() {
+  const container = document.querySelector('[data-specs]');
+  if (!container) {
+    return;
+  }
+
+  container.textContent = 'Run spec extraction to populate mechanical requirements.';
+}


### PR DESCRIPTION
## Summary
- add the phase P4 spec extraction service with deterministic fallbacks and persistence
- wire the /specs routes to load artifacts, invoke the service, and auto-populate persisted specs
- cover the end-to-end spec workflow with a deterministic test and add a minimal specs UI stub

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df1534565c8324bc81c93da09725e0