### PR TITLE
Add spec deduplication and merge test

### DIFF
--- a/backend/services/specs.py
+++ b/backend/services/specs.py
@@ -172,6 +172,7 @@ def extract_specs_for_sections(
     order_index = {obj.object_id: idx for idx, obj in enumerate(ordered_objects)}
 
     specs: list[SpecItem] = []
+    seen_pairs: set[tuple[tuple[str, ...], str]] = set()
 
     leaves = list(_iter_leaves(root))
     fallback_map = _build_fallback_mapping(leaves, chunk_map, ordered_objects, order_index)
@@ -212,6 +213,10 @@ def extract_specs_for_sections(
                 continue
             spec_id_seed = f"{file_id}|{section.section_id}|{index}|{spec_text}"
             spec_id = hashlib.sha1(spec_id_seed.encode("utf-8")).hexdigest()
+            dedup_key = (tuple(sorted_ids), spec_text.lower())
+            if dedup_key in seen_pairs:
+                continue
+            seen_pairs.add(dedup_key)
             specs.append(
                 SpecItem(
                     spec_id=spec_id,

--- a/backend/tests/test_specs_merge.py
+++ b/backend/tests/test_specs_merge.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.config import get_settings
+from backend.models import ParsedObject, SectionNode
+from backend.services.specs import extract_specs_for_sections
+
+
+class _DeterministicAdapter:
+    """Adapter that returns predefined responses for each call."""
+
+    def __init__(self, responses: list[str]) -> None:
+        self._responses = responses
+        self._index = 0
+
+    def generate(self, prompt: str) -> str:  # noqa: D401 - simple deterministic stub
+        if self._index >= len(self._responses):
+            return self._responses[-1]
+        response = self._responses[self._index]
+        self._index += 1
+        return response
+
+
+def _build_section(section_id: str, file_id: str, title: str, number: str | None = None) -> SectionNode:
+    return SectionNode(
+        section_id=section_id,
+        file_id=file_id,
+        number=number,
+        title=title,
+        depth=1,
+        children=[],
+    )
+
+
+def test_dedup_and_merge(tmp_path, monkeypatch) -> None:
+    """Specs with identical provenance are deduplicated while unique items persist."""
+
+    artifacts_dir = tmp_path / "artifacts"
+    monkeypatch.setenv("SIMPLS_ARTIFACTS_DIR", str(artifacts_dir))
+    get_settings.cache_clear()
+
+    file_id = "file-123"
+    chunks_dir = artifacts_dir / file_id / "chunks"
+    chunks_dir.mkdir(parents=True)
+    chunk_map = {"sec-1": ["obj-1", "obj-2"], "sec-2": ["obj-1", "obj-2"]}
+    (chunks_dir / "chunks.json").write_text(json.dumps(chunk_map))
+
+    objects = [
+        ParsedObject(
+            object_id="obj-1",
+            file_id=file_id,
+            kind="text",
+            text="- Maximum load 500 N",
+            page_index=0,
+            order_index=0,
+        ),
+        ParsedObject(
+            object_id="obj-2",
+            file_id=file_id,
+            kind="text",
+            text="- Allowable stress per ASTM A36",
+            page_index=0,
+            order_index=1,
+        ),
+    ]
+
+    root = SectionNode(
+        section_id="root",
+        file_id=file_id,
+        number=None,
+        title="Root",
+        depth=0,
+        children=[
+            _build_section("sec-1", file_id, "Specifications", "1"),
+            _build_section("sec-2", file_id, "More Specifications", "2"),
+        ],
+    )
+
+    adapter = _DeterministicAdapter(
+        [
+            "- Maximum load 500 N\n- Maximum load 500 N",
+            "- Maximum load 500 N\n- Allowable stress per ASTM A36",
+        ]
+    )
+
+    specs = extract_specs_for_sections(file_id, root, objects, adapter)
+
+    assert [item.spec_text for item in specs] == [
+        "Maximum load 500 N",
+        "Allowable stress per ASTM A36",
+    ]
+    assert specs[0].section_id == "sec-1"
+    assert specs[1].section_id == "sec-2"
+    for item in specs:
+        assert item.source_object_ids == ["obj-1", "obj-2"]
+
+    persisted = Path(artifacts_dir / file_id / "specs" / "specs.json")
+    assert persisted.exists()
+    payload = json.loads(persisted.read_text())
+    assert [entry["spec_text"] for entry in payload] == [
+        "Maximum load 500 N",
+        "Allowable stress per ASTM A36",
+    ]
+
+    get_settings.cache_clear()


### PR DESCRIPTION
## Summary
- avoid emitting duplicate specs by tracking previously seen provenance/text pairs in the extraction loop
- add a regression test covering deduplication and persistence of merged specs

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df1a801a208324a601c2a1523efbd0