### PR TITLE
Align phase 4 specs implementation with final stubs

### DIFF
--- a/backend/services/specs.py
+++ b/backend/services/specs.py
@@ -161,11 +161,10 @@ def extract_specs_for_sections(
     root: SectionNode,
     objects: list[ParsedObject],
     adapter: LLMAdapter,
-    settings: Settings | None = None,
 ) -> list[SpecItem]:
     """Iterate document leaves, run the adapter, and persist specs."""
 
-    settings = settings or get_settings()
+    settings = get_settings()
     chunk_map = _load_chunks(file_id, settings)
     indexed_objects = {obj.object_id: obj for obj in objects}
     ordered_objects = _sorted_objects(objects)

--- a/backend/tests/test_specs_loop_resume.py
+++ b/backend/tests/test_specs_loop_resume.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import sys
+import tempfile
 from io import BytesIO
 from pathlib import Path
 
@@ -21,72 +23,77 @@ def _hash_payload(payload: list[dict[str, object]]) -> str:
     return hashlib.sha1(serialized.encode("utf-8")).hexdigest()
 
 
-def test_resume_on_failure(tmp_path, monkeypatch) -> None:
+def test_resume_on_failure() -> None:
     """Spec extraction endpoints persist deterministic results across adapters."""
 
-    artifacts_dir = tmp_path / "artifacts"
-    monkeypatch.setenv("SIMPLS_ARTIFACTS_DIR", str(artifacts_dir))
-    get_settings.cache_clear()
-    client = TestClient(create_app())
+    original = os.environ.get("SIMPLS_ARTIFACTS_DIR")
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        artifacts_dir = Path(tmp_dir) / "artifacts"
+        os.environ["SIMPLS_ARTIFACTS_DIR"] = str(artifacts_dir)
+        get_settings.cache_clear()
+        client = TestClient(create_app())
 
-    content = (
-        "1. Introduction\n"
-        "Overview of the system.\n"
-        "1.1 Background\n"
-        "- The actuator shall withstand 500 N axial load.\n"
-        "2. Methods\n"
-        "- Operating temperature range 0 to 60 °C.\n"
-        "3. Results\n"
-        "Materials shall comply with ISO 2768.\n"
-    ).encode("utf-8")
+        content = (
+            "1. Introduction\n"
+            "Overview of the system.\n"
+            "1.1 Background\n"
+            "- The actuator shall withstand 500 N axial load.\n"
+            "2. Methods\n"
+            "- Operating temperature range 0 to 60 °C.\n"
+            "3. Results\n"
+            "Materials shall comply with ISO 2768.\n"
+        ).encode("utf-8")
 
-    ingest = client.post(
-        "/ingest",
-        files={"file": ("specs.txt", BytesIO(content), "text/plain")},
-    )
-    assert ingest.status_code == 200
-    file_id = ingest.json()["file_id"]
+        ingest = client.post(
+            "/ingest",
+            files={"file": ("specs.txt", BytesIO(content), "text/plain")},
+        )
+        assert ingest.status_code == 200
+        file_id = ingest.json()["file_id"]
 
-    headers = client.post(f"/headers/{file_id}/find")
-    assert headers.status_code == 200
+        headers = client.post(f"/headers/{file_id}/find")
+        assert headers.status_code == 200
 
-    chunk_response = client.post(f"/chunks/{file_id}")
-    assert chunk_response.status_code == 200
-    chunk_map = chunk_response.json()
+        chunk_response = client.post(f"/chunks/{file_id}")
+        assert chunk_response.status_code == 200
+        chunk_map = chunk_response.json()
 
-    first = client.post(f"/specs/{file_id}/find", params={"llm": "openrouter"})
-    assert first.status_code == 200
-    first_specs = first.json()
-    assert isinstance(first_specs, list)
-    assert first_specs
+        first = client.post(f"/specs/{file_id}/find", params={"llm": "openrouter"})
+        assert first.status_code == 200
+        first_specs = first.json()
+        assert isinstance(first_specs, list)
+        assert first_specs
 
-    repeat = client.post(f"/specs/{file_id}/find", params={"llm": "openrouter"})
-    assert repeat.status_code == 200
-    second_specs = repeat.json()
-    assert _hash_payload(second_specs) == _hash_payload(first_specs)
+        repeat = client.post(f"/specs/{file_id}/find", params={"llm": "openrouter"})
+        assert repeat.status_code == 200
+        second_specs = repeat.json()
+        assert _hash_payload(second_specs) == _hash_payload(first_specs)
 
-    llama = client.post(f"/specs/{file_id}/find", params={"llm": "llamacpp"})
-    assert llama.status_code == 200
-    llama_specs = llama.json()
-    assert llama_specs == first_specs
+        llama = client.post(f"/specs/{file_id}/find", params={"llm": "llamacpp"})
+        assert llama.status_code == 200
+        llama_specs = llama.json()
+        assert llama_specs == first_specs
 
-    persisted = client.get(f"/specs/{file_id}")
-    assert persisted.status_code == 200
-    assert persisted.json() == first_specs
+        persisted = client.get(f"/specs/{file_id}")
+        assert persisted.status_code == 200
+        assert persisted.json() == first_specs
 
-    for item in first_specs:
-        assert set(item.keys()) == {
-            "spec_id",
-            "file_id",
-            "section_id",
-            "section_number",
-            "section_title",
-            "spec_text",
-            "confidence",
-            "source_object_ids",
-        }
-        assert item["source_object_ids"] == chunk_map[item["section_id"]]
-        assert item["file_id"] == file_id
-        assert item["spec_text"].strip() == item["spec_text"]
-
+        for item in first_specs:
+            assert set(item.keys()) == {
+                "spec_id",
+                "file_id",
+                "section_id",
+                "section_number",
+                "section_title",
+                "spec_text",
+                "confidence",
+                "source_object_ids",
+            }
+            assert item["source_object_ids"] == chunk_map[item["section_id"]]
+            assert item["file_id"] == file_id
+            assert item["spec_text"].strip() == item["spec_text"]
+    if original is None:
+        os.environ.pop("SIMPLS_ARTIFACTS_DIR", None)
+    else:
+        os.environ["SIMPLS_ARTIFACTS_DIR"] = original
     get_settings.cache_clear()


### PR DESCRIPTION
## Summary
- align `extract_specs_for_sections` with the Phase 4 stub signature by removing the unused settings parameter
- update spec extraction tests to manage temporary artifact directories without pytest fixtures so they match the published stubs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68df1de713508324b4aa3ff97c10a792