### PR TITLE
Implement QA report and export endpoints

### DIFF
--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -1,11 +1,49 @@
 """File-related routes that complement ingestion."""
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, status
+from collections import Counter
+import csv
+import hashlib
+import io
+import json
+from pathlib import Path
+from typing import Any, Iterable, Iterator
 
+from fastapi import APIRouter, HTTPException, Query, status
+from fastapi.responses import StreamingResponse
+
+from ..config import get_settings
+from ..models import SectionNode, SpecItem
 from ..services.chunker import load_persisted_chunks, run_chunking
 
 files_router = APIRouter(prefix="", tags=["files"])
+
+
+def _iter_leaves(node: SectionNode) -> Iterator[SectionNode]:
+    if not node.children:
+        yield node
+        return
+    for child in node.children:
+        yield from _iter_leaves(child)
+
+
+def _compute_sha256(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _sorted_specs(specs: Iterable[SpecItem]) -> list[SpecItem]:
+    return sorted(specs, key=lambda item: (item.section_title, item.spec_id))
+
+
+def _load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
 
 
 @files_router.post("/chunks/{file_id}", response_model=dict[str, list[str]])
@@ -28,3 +66,205 @@ def get_chunks(file_id: str) -> dict[str, list[str]]:
     except FileNotFoundError as exc:
         detail = str(exc) or "Chunks not found."
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail) from exc
+
+
+@files_router.get("/qa/{file_id}")
+def qa_report(file_id: str) -> dict[str, Any]:
+    """Return quality assurance metrics for the processed file."""
+
+    settings = get_settings()
+    base = Path(settings.ARTIFACTS_DIR) / file_id
+    parsed_path = base / "parsed" / "objects.json"
+    sections_path = base / "headers" / "sections.json"
+    chunks_path = base / "chunks" / "chunks.json"
+    specs_path = base / "specs" / "specs.json"
+
+    if not parsed_path.exists():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Parsed objects missing.",
+        )
+    if not sections_path.exists():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Header sections missing.",
+        )
+    if not chunks_path.exists():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Section chunks missing.",
+        )
+
+    parsed_objects: list[dict[str, Any]] = _load_json(parsed_path)
+    section_root = SectionNode.model_validate(_load_json(sections_path))
+    chunk_map_raw = _load_json(chunks_path)
+    chunk_map: dict[str, list[str]] = {
+        key: [str(item) for item in value]
+        for key, value in chunk_map_raw.items()
+    }
+
+    specs_present = specs_path.exists()
+    specs: list[SpecItem] = []
+    if specs_present:
+        specs_payload = _load_json(specs_path)
+        specs = [SpecItem.model_validate(item) for item in specs_payload]
+
+    leaves = list(_iter_leaves(section_root))
+    leaf_ids = {leaf.section_id for leaf in leaves}
+    specs_by_section: Counter[str] = Counter(spec.section_id for spec in specs)
+    leaves_with_specs = sum(1 for leaf in leaves if specs_by_section.get(leaf.section_id))
+
+    duplicate_ids: set[str] = set()
+    seen_ids: set[str] = set()
+    for spec in specs:
+        if spec.spec_id in seen_ids:
+            duplicate_ids.add(spec.spec_id)
+        seen_ids.add(spec.spec_id)
+
+    mismatched_specs: list[str] = []
+    for spec in specs:
+        expected = chunk_map.get(spec.section_id, [])
+        if spec.section_id not in leaf_ids or spec.source_object_ids != expected:
+            mismatched_specs.append(spec.spec_id)
+
+    warnings: list[str] = []
+    if mismatched_specs:
+        joined = ", ".join(sorted(mismatched_specs))
+        warnings.append(f"Source-object mismatch for spec_ids: {joined}")
+    if duplicate_ids:
+        joined = ", ".join(sorted(duplicate_ids))
+        warnings.append(f"Duplicate spec_ids detected: {joined}")
+
+    coverage = {
+        "parsed_object_count": len(parsed_objects),
+        "leaf_section_count": len(leaves),
+        "specs_count": len(specs),
+        "leaf_spec_ratio": (leaves_with_specs / len(leaves)) if leaves else 0.0,
+    }
+
+    consistency = {
+        "source_alignment": not mismatched_specs,
+        "unique_spec_ids": not duplicate_ids,
+        "sections_present": True,
+        "chunks_present": True,
+        "specs_present": specs_present,
+    }
+
+    determinism = {
+        "sections_sha256": _compute_sha256(sections_path),
+        "chunks_sha256": _compute_sha256(chunks_path),
+        "specs_sha256": _compute_sha256(specs_path) if specs_present else None,
+    }
+
+    return {
+        "file_id": file_id,
+        "qa": {
+            "coverage": coverage,
+            "consistency": consistency,
+            "determinism": determinism,
+            "warnings": warnings,
+        },
+    }
+
+
+@files_router.get("/export/{file_id}")
+def export_file(file_id: str, fmt: str = Query(default="json")) -> StreamingResponse:
+    """Export sections and specs as JSON or CSV."""
+
+    settings = get_settings()
+    base = Path(settings.ARTIFACTS_DIR) / file_id
+    parsed_path = base / "parsed" / "objects.json"
+    sections_path = base / "headers" / "sections.json"
+    chunks_path = base / "chunks" / "chunks.json"
+    specs_path = base / "specs" / "specs.json"
+
+    if not parsed_path.exists():
+        if not base.exists():
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found.")
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Parsed objects missing.",
+        )
+    if not sections_path.exists():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Header sections missing.",
+        )
+    if not chunks_path.exists():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Section chunks missing.",
+        )
+    if not specs_path.exists():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Specs not found.",
+        )
+
+    normalized = fmt.lower()
+    if normalized not in {"json", "csv"}:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unsupported export format.",
+        )
+
+    section_root = SectionNode.model_validate(_load_json(sections_path))
+    specs_payload = [SpecItem.model_validate(item) for item in _load_json(specs_path)]
+    ordered_specs = _sorted_specs(specs_payload)
+
+    if normalized == "json":
+        content = json.dumps(
+            {
+                "file_id": file_id,
+                "sections": [section_root.model_dump(mode="json")],
+                "specs": [item.model_dump(mode="json") for item in ordered_specs],
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        headers = {
+            "Content-Disposition": f'attachment; filename="export_{file_id}.json"'
+        }
+        return StreamingResponse(
+            iter([content.encode("utf-8")]),
+            media_type="application/json",
+            headers=headers,
+        )
+
+    header_row = [
+        "spec_id",
+        "file_id",
+        "section_id",
+        "section_number",
+        "section_title",
+        "spec_text",
+        "confidence",
+        "source_object_ids",
+    ]
+
+    def row_iter() -> Iterator[bytes]:
+        buffer = io.StringIO()
+        writer = csv.writer(buffer, lineterminator="\n")
+        writer.writerow(header_row)
+        yield buffer.getvalue().encode("utf-8")
+        for item in ordered_specs:
+            buffer = io.StringIO()
+            writer = csv.writer(buffer, lineterminator="\n")
+            writer.writerow(
+                [
+                    item.spec_id,
+                    item.file_id,
+                    item.section_id,
+                    item.section_number or "",
+                    item.section_title,
+                    item.spec_text,
+                    "" if item.confidence is None else f"{item.confidence}",
+                    json.dumps(item.source_object_ids, ensure_ascii=False, separators=(",", ":")),
+                ]
+            )
+            yield buffer.getvalue().encode("utf-8")
+
+    headers = {
+        "Content-Disposition": f'attachment; filename="export_{file_id}.csv"'
+    }
+    return StreamingResponse(row_iter(), media_type="text/csv", headers=headers)

--- a/backend/tests/test_export_csv_json.py
+++ b/backend/tests/test_export_csv_json.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+import sys
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.config import get_settings
+from backend.main import create_app
+
+client = TestClient(create_app())
+settings = get_settings()
+
+
+def _run_pipeline() -> str:
+    content = (
+        "1. Overview\n"
+        "This document outlines requirements.\n"
+        "1.1 Scope\n"
+        "Maximum pressure is 20 MPa.\n"
+        "1.2 Materials\n"
+        "Use ASTM A36 steel throughout.\n"
+    ).encode("utf-8")
+    ingest = client.post(
+        "/ingest",
+        files={"file": ("sample.txt", BytesIO(content), "text/plain")},
+    )
+    assert ingest.status_code == 200
+    file_id = ingest.json()["file_id"]
+
+    headers = client.post(f"/headers/{file_id}/find")
+    assert headers.status_code == 200
+
+    chunks = client.post(f"/chunks/{file_id}")
+    assert chunks.status_code == 200
+
+    specs = client.post(f"/specs/{file_id}/find")
+    assert specs.status_code == 200
+
+    return file_id
+
+
+def test_export_formats() -> None:
+    file_id = _run_pipeline()
+
+    qa_response = client.get(f"/qa/{file_id}")
+    assert qa_response.status_code == 200
+    qa_payload = qa_response.json()
+    assert qa_payload["file_id"] == file_id
+    qa_section = qa_payload["qa"]
+    assert {"coverage", "consistency", "determinism", "warnings"} <= qa_section.keys()
+    assert isinstance(qa_section["warnings"], list)
+
+    export_json_1 = client.get(f"/export/{file_id}")
+    assert export_json_1.status_code == 200
+    assert export_json_1.headers["content-type"].startswith("application/json")
+    assert export_json_1.headers["content-disposition"] == (
+        f'attachment; filename="export_{file_id}.json"'
+    )
+    json_payload = export_json_1.json()
+    assert json_payload["file_id"] == file_id
+    assert isinstance(json_payload["sections"], list)
+    assert isinstance(json_payload["specs"], list)
+
+    export_json_2 = client.get(f"/export/{file_id}")
+    assert export_json_2.status_code == 200
+    assert export_json_1.content == export_json_2.content
+
+    export_csv_1 = client.get(f"/export/{file_id}", params={"fmt": "csv"})
+    assert export_csv_1.status_code == 200
+    assert export_csv_1.headers["content-type"].startswith("text/csv")
+    assert export_csv_1.headers["content-disposition"] == (
+        f'attachment; filename="export_{file_id}.csv"'
+    )
+    csv_lines = export_csv_1.text.splitlines()
+    assert csv_lines
+    assert (
+        csv_lines[0]
+        == "spec_id,file_id,section_id,section_number,section_title,spec_text,confidence,source_object_ids"
+    )
+
+    export_csv_2 = client.get(f"/export/{file_id}", params={"fmt": "csv"})
+    assert export_csv_2.status_code == 200
+    assert export_csv_1.content == export_csv_2.content
+
+    missing = client.get("/export/unknown-file")
+    assert missing.status_code == 404
+
+    specs_path = Path(settings.ARTIFACTS_DIR) / file_id / "specs" / "specs.json"
+    assert specs_path.exists()
+    backup_path = specs_path.with_suffix(".bak")
+    specs_path.rename(backup_path)
+    try:
+        missing_specs = client.get(f"/export/{file_id}")
+        assert missing_specs.status_code == 404
+
+        qa_missing = client.get(f"/qa/{file_id}")
+        assert qa_missing.status_code == 200
+        qa_payload_missing = qa_missing.json()["qa"]
+        assert qa_payload_missing["consistency"]["specs_present"] is False
+    finally:
+        backup_path.rename(specs_path)
+
+    # Reload QA to ensure restored artifacts behave deterministically.
+    qa_restored = client.get(f"/qa/{file_id}")
+    assert qa_restored.status_code == 200


### PR DESCRIPTION
## Summary
- add a QA reporting route that inspects coverage, consistency, and artifact hashes
- implement deterministic JSON and CSV export endpoints with proper error handling
- add an integration test that exercises QA, exports, determinism, and error paths

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df22d85ed48324ae82870546543d33