### PR TITLE
Replace parsed objects sidebar with headers overview

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,12 +28,12 @@
             <div id="drop-zone" class="drop-zone">Drop files here</div>
             <button id="upload-button" type="button" class="primary">Upload &amp; Parse</button>
           </section>
-          <section class="objects-panel">
+          <section class="headers-panel">
             <header>
-              <h2>Parsed Objects</h2>
-              <span id="object-count" class="pill">0</span>
+              <h2>Headers</h2>
+              <span id="headers-count" class="pill">0</span>
             </header>
-            <div id="objects-list" class="virtual-list"></div>
+            <div id="sidebar-headers" class="headers-sidebar"></div>
           </section>
         </aside>
         <main class="right-pane">

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -4,6 +4,7 @@ export const state = {
   headers: [],
   specs: [],
   sectionTexts: new Map(),
+  headerProgress: new Map(),
   provider: "openrouter",
   model: "",
   params: {
@@ -21,6 +22,7 @@ export function setUpload({ uploadId, objectCount, objects }) {
   state.headers = [];
   state.specs = [];
   state.sectionTexts = new Map();
+  state.headerProgress = new Map();
 }
 
 export function setObjects(objects) {
@@ -29,10 +31,26 @@ export function setObjects(objects) {
 
 export function setHeaders(headers) {
   state.headers = headers;
+  state.headerProgress = new Map();
+  headers.forEach((header) => {
+    if (header?.section_number) {
+      const key = String(header.section_number);
+      state.headerProgress.set(key, false);
+    }
+  });
 }
 
 export function setSpecs(specs) {
   state.specs = specs;
+}
+
+export function markHeaderProcessed(sectionNumber) {
+  if (!sectionNumber) return;
+  if (!state.headerProgress) {
+    state.headerProgress = new Map();
+  }
+  const key = String(sectionNumber);
+  state.headerProgress.set(key, true);
 }
 
 export function setSectionText(sectionNumber, text) {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -155,7 +155,7 @@ button:hover {
   background: rgba(56, 189, 248, 0.2);
 }
 
-.objects-panel {
+.headers-panel {
   flex: 1;
   background: var(--surface-alt);
   border: 1px solid var(--border);
@@ -166,7 +166,7 @@ button:hover {
   min-height: 0;
 }
 
-.objects-panel header {
+.headers-panel header {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -181,50 +181,70 @@ button:hover {
   font-size: 0.8rem;
 }
 
-.virtual-list {
-  position: relative;
+.headers-sidebar {
   flex: 1;
   overflow-y: auto;
   border: 1px solid var(--border);
   border-radius: 0.5rem;
   background: rgba(15, 23, 42, 0.6);
+  padding: 0.5rem;
 }
 
-.virtual-list-inner {
-  position: relative;
-  width: 100%;
-}
-
-.virtual-row {
-  position: absolute;
-  left: 0;
-  right: 0;
-  padding: 0.65rem 0.75rem;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+.headers-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
 }
 
-.virtual-row .meta {
+.headers-list li {
+  margin: 0;
+}
+
+.header-node {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  font-size: 0.75rem;
+  gap: 0.5rem;
+  width: 100%;
+  background: none;
+  border: none;
+  color: inherit;
+  text-align: left;
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.header-node:hover {
+  background: rgba(56, 189, 248, 0.12);
+  color: var(--accent);
+}
+
+.header-node.active {
+  background: rgba(56, 189, 248, 0.2);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.header-status {
+  width: 1.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
   color: var(--muted);
 }
 
-.type-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  background: rgba(56, 189, 248, 0.15);
-  color: var(--accent);
-  padding: 0.125rem 0.5rem;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.02em;
+.header-status--complete {
+  color: #22c55e;
+}
+
+.header-label {
+  flex: 1;
+  white-space: normal;
 }
 
 .preview {
@@ -351,24 +371,18 @@ button:hover {
   font-size: 0.9rem;
 }
 
+.headers-tree > ul {
+  padding-left: 0;
+}
+
 .headers-tree ul {
   list-style: none;
   margin: 0;
-  padding-left: 1rem;
+  padding-left: 0.75rem;
 }
 
 .headers-tree li {
-  margin: 0.25rem 0;
-  cursor: pointer;
-}
-
-.headers-tree li:hover {
-  color: var(--accent);
-}
-
-.headers-tree li.active {
-  color: var(--accent);
-  font-weight: 600;
+  margin: 0.15rem 0;
 }
 
 .specs-controls {


### PR DESCRIPTION
## Summary
- replace the parsed objects sidebar with a headers summary list that shows the extracted header count
- track per-header specification progress and display green checkmarks in the header navigation once sections are processed
- refresh header preview defaults on new uploads and restyle header navigation elements to match the new layout

## Testing
- Manually started `python -m http.server 8000` and loaded the app in a browser to verify the new headers sidebar renders


------
https://chatgpt.com/codex/tasks/task_e_68dfc97822e88324a4931a1e4b27b184