### PR TITLE
Fix SQLModel relationship typing

### DIFF
--- a/backend/db_models.py
+++ b/backend/db_models.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from sqlalchemy import JSON, UniqueConstraint
 from sqlmodel import Column, Field, Relationship, SQLModel
@@ -18,13 +18,13 @@ class Document(SQLModel, table=True):
     filename: str = Field(nullable=False)
     file_hash: str = Field(index=True, unique=True, nullable=False)
     object_count: int = Field(default=0, nullable=False)
-    parsed_objects: List[Dict[str, Any]] = Field(
+    parsed_objects: list[Dict[str, Any]] = Field(
         default_factory=list,
         sa_column=Column(JSON),
     )
     created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
 
-    steps: List["DocumentStep"] = Relationship(back_populates="document")
+    steps: list["DocumentStep"] = Relationship(back_populates="document")
 
 
 class DocumentStep(SQLModel, table=True):
@@ -37,7 +37,7 @@ class DocumentStep(SQLModel, table=True):
     document_id: int = Field(foreign_key="documents.id", nullable=False)
     name: str = Field(index=True, nullable=False)
     status: str = Field(default="pending", nullable=False)
-    result: Optional[List[Dict[str, Any]]] = Field(
+    result: Optional[list[Dict[str, Any]]] = Field(
         default=None,
         sa_column=Column(JSON),
     )


### PR DESCRIPTION
## Summary
- update SQLModel models to use PEP 604 style list annotations
- ensure relationship targets are inferred correctly to avoid mapper configuration errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfd1748d7c832494adfc54f4016a1e