### PR TITLE
Fix SQLModel mappings initialization

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from functools import lru_cache
 from typing import Iterator
 
 from sqlmodel import Session, SQLModel, create_engine
@@ -10,12 +9,8 @@ from sqlmodel import Session, SQLModel, create_engine
 from .config import get_settings
 
 
-@lru_cache(maxsize=1)
-def _get_engine():
-    """Return the configured SQLModel engine."""
-
-    settings = get_settings()
-    return create_engine(settings.DB_URL, echo=False)
+settings = get_settings()
+engine = create_engine(settings.DB_URL, echo=False)
 
 
 def init_db() -> None:
@@ -24,13 +19,12 @@ def init_db() -> None:
     # Import models for metadata registration.
     from . import db_models  # noqa: F401  # pylint: disable=unused-import
 
-    SQLModel.metadata.create_all(_get_engine())
+    SQLModel.metadata.create_all(engine)
 
 
 @contextmanager
 def get_session() -> Iterator[Session]:
     """Context manager yielding a SQLModel session."""
 
-    engine = _get_engine()
     with Session(engine) as session:
         yield session

--- a/backend/db_models.py
+++ b/backend/db_models.py
@@ -24,7 +24,10 @@ class Document(SQLModel, table=True):
     )
     created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
 
-    steps: list["DocumentStep"] = Relationship(back_populates="document")
+    steps: list["DocumentStep"] = Relationship(
+        back_populates="document",
+        sa_relationship_kwargs={"cascade": "all, delete-orphan"},
+    )
 
 
 class DocumentStep(SQLModel, table=True):
@@ -49,4 +52,4 @@ class DocumentStep(SQLModel, table=True):
     created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
     updated_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
 
-    document: Document = Relationship(back_populates="steps")
+    document: "Document" = Relationship(back_populates="steps")

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,6 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
-from .db import init_db
 from .routers import export, health, headers, specs, upload
 
 app = FastAPI(title="SimpleSpecs", version="1.0.0")
@@ -20,7 +19,14 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-init_db()
+
+@app.on_event("startup")
+def _startup() -> None:
+    """Initialise database tables when the application starts."""
+
+    from .db import init_db
+
+    init_db()
 
 app.include_router(health.router)
 app.include_router(upload.router)


### PR DESCRIPTION
## Summary
- ensure SQLModel engine is created once and metadata loads after importing models
- add startup hook to create tables after application launch
- tighten document relationship configuration with explicit cascade handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfd37786848324a6b16cbf851ca05c