### PR TITLE
Restrict CORS configuration to known frontend hosts

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -13,10 +13,11 @@ app = FastAPI(title="SimpleSpecs", version="1.0.0")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=["http://127.0.0.1:3000", "http://localhost:3000"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["*"],
 )
 
 


### PR DESCRIPTION
## Summary
- limit FastAPI CORS configuration to explicit localhost frontend origins
- expose response headers while keeping credentialed requests supported

## Testing
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68dfe3caa2608324a83482f3abbff4e9