### PR TITLE
Support Ollama chat endpoint for llama.cpp provider

### DIFF
--- a/backend/services/llm/llamacpp.py
+++ b/backend/services/llm/llamacpp.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Any, List
+from urllib.parse import urlparse
 
 import httpx
 
@@ -13,15 +14,43 @@ class LlamaCPPProvider(LLMProvider):
         super().__init__(model=model, params=params)
         self.base_url = base_url.rstrip("/")
 
+        params_copy = dict(self.params)
+        endpoint_path = params_copy.pop("endpoint_path", None)
+        self.params = params_copy
+
+        if isinstance(endpoint_path, str) and endpoint_path.startswith("http"):
+            self.request_url = endpoint_path.rstrip("/")
+        elif isinstance(endpoint_path, str) and endpoint_path:
+            self.request_url = f"{self.base_url}/{endpoint_path.lstrip('/')}"
+        else:
+            parsed = urlparse(self.base_url)
+            if parsed.path and parsed.path != "/":
+                self.request_url = self.base_url
+            else:
+                self.request_url = f"{self.base_url}/v1/chat/completions"
+
     async def _chat(self, messages: List[dict[str, str]]) -> str:
         payload: dict[str, Any] = {"model": self.model, "messages": messages}
         payload.update(self.params)
-        url = f"{self.base_url}/v1/chat/completions"
+        payload.setdefault("stream", False)
+        url = self.request_url
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.post(url, json=payload)
         response.raise_for_status()
         data = response.json()
-        try:
-            return data["choices"][0]["message"]["content"].strip()
-        except (KeyError, IndexError, TypeError) as exc:  # noqa: PERF203 - explicit handling
-            raise RuntimeError(f"Unexpected response structure: {data}") from exc
+        content: Any | None = None
+        if isinstance(data, dict):
+            choices = data.get("choices")
+            if isinstance(choices, list) and choices:
+                first_choice = choices[0]
+                if isinstance(first_choice, dict):
+                    message = first_choice.get("message")
+                    if isinstance(message, dict):
+                        content = message.get("content")
+            if content is None:
+                message = data.get("message")
+                if isinstance(message, dict):
+                    content = message.get("content")
+        if not isinstance(content, str):
+            raise RuntimeError(f"Unexpected response structure: {data}")
+        return content.strip()

--- a/backend/tests/test_llamacpp_provider.py
+++ b/backend/tests/test_llamacpp_provider.py
@@ -1,0 +1,87 @@
+"""Tests for the llama.cpp provider integration."""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import httpx
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.services.llm.llamacpp import LlamaCPPProvider
+
+
+def _make_mock_async_client(
+    expected_url: str,
+    expected_payload: dict,
+    response_json: dict,
+):
+    class _MockAsyncClient:
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401 - test helper
+            pass
+
+        async def __aenter__(self) -> "_MockAsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def post(self, url: str, json: dict):
+            assert url == expected_url
+            assert json == expected_payload
+            request = httpx.Request("POST", expected_url, json=json)
+            return httpx.Response(200, json=response_json, request=request)
+
+    return _MockAsyncClient
+
+
+def test_llamacpp_provider_openai_style(monkeypatch):
+    messages = [{"role": "user", "content": "Hi"}]
+    provider = LlamaCPPProvider(
+        model="test-model",
+        params={"temperature": 0.7},
+        base_url="http://llama.example",
+    )
+    expected_payload = {
+        "model": "test-model",
+        "messages": messages,
+        "temperature": 0.7,
+        "stream": False,
+    }
+    response_json = {"choices": [{"message": {"content": "Hello! "}}]}
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        _make_mock_async_client("http://llama.example/v1/chat/completions", expected_payload, response_json),
+    )
+
+    result = asyncio.run(provider._chat(messages))
+
+    assert result == "Hello!"
+
+
+def test_llamacpp_provider_ollama_style(monkeypatch):
+    messages = [{"role": "user", "content": "Tell me a joke"}]
+    provider = LlamaCPPProvider(
+        model="ollama-model",
+        params={"endpoint_path": "/api/chat", "stream": True},
+        base_url="http://localhost:11434",
+    )
+    expected_payload = {
+        "model": "ollama-model",
+        "messages": messages,
+        "stream": True,
+    }
+    response_json = {"message": {"role": "assistant", "content": "Knock knock."}}
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        _make_mock_async_client("http://localhost:11434/api/chat", expected_payload, response_json),
+    )
+
+    result = asyncio.run(provider._chat(messages))
+
+    assert result == "Knock knock."


### PR DESCRIPTION
## Summary
- allow the llama.cpp provider to target configurable endpoints including Ollama's /api/chat
- default chat payloads to non-streaming and handle both OpenAI and Ollama style response bodies
- add tests that mock both response shapes to ensure the extracted assistant message is correct

## Testing
- pytest backend/tests/test_llamacpp_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68dffe7833948324855757da8ad18664