### PR TITLE
Use shared max token constants across backend and frontend

### DIFF
--- a/backend/constants.py
+++ b/backend/constants.py
@@ -1,0 +1,4 @@
+"""Shared constants for the SimpleSpecs backend."""
+
+MAX_TOKENS_LIMIT = 20_000
+"""Default maximum number of tokens used across the application."""

--- a/backend/models_db.py
+++ b/backend/models_db.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from sqlmodel import Field, SQLModel
 
+from backend.constants import MAX_TOKENS_LIMIT
+
 
 class ModelSettingsBase(SQLModel):
     """Shared fields for model settings records."""
@@ -11,7 +13,7 @@ class ModelSettingsBase(SQLModel):
     provider: str = Field(default="openrouter", max_length=50)
     model: str = Field(default="", max_length=255)
     temperature: float = Field(default=0.2, ge=0.0, le=2.0)
-    max_tokens: int = Field(default=20000, ge=16, le=32768)
+    max_tokens: int = Field(default=MAX_TOKENS_LIMIT, ge=16, le=32768)
     api_key: str | None = Field(default=None, max_length=512)
     base_url: str | None = Field(default=None, max_length=512)
 

--- a/backend/services/headers.py
+++ b/backend/services/headers.py
@@ -8,6 +8,8 @@ from typing import Iterator, Optional, Sequence
 
 import httpx
 
+from ..constants import MAX_TOKENS_LIMIT
+
 from ..config import Settings, get_settings
 from ..models import ParsedObject, SectionNode, SectionSpan
 from .llm_client import LLMAdapter
@@ -284,7 +286,7 @@ class _OpenRouterAdapter:
                 {"role": "user", "content": prompt},
             ],
             "temperature": 0.0,
-            "max_tokens": 20000,
+            "max_tokens": MAX_TOKENS_LIMIT,
         }
         try:
             response = httpx.post(
@@ -318,7 +320,7 @@ class _LlamaCppAdapter:
                 json={
                     "prompt": prompt,
                     "temperature": 0.0,
-                    "max_tokens": 20000,
+                    "max_tokens": MAX_TOKENS_LIMIT,
                 },
                 timeout=10.0,
             )

--- a/backend/tests/test_model_settings.py
+++ b/backend/tests/test_model_settings.py
@@ -11,6 +11,7 @@ from backend.config import get_settings
 from backend.main import create_app
 from backend.database import init_db, get_engine
 from sqlalchemy import inspect
+from backend.constants import MAX_TOKENS_LIMIT
 
 
 def _create_client(monkeypatch, tmp_path: Path) -> TestClient:
@@ -31,14 +32,14 @@ def test_model_settings_persist_between_requests(monkeypatch, tmp_path):
     assert initial.status_code == 200
     payload = initial.json()
     assert payload["provider"] == "openrouter"
-    assert payload["max_tokens"] == 20000
+    assert payload["max_tokens"] == MAX_TOKENS_LIMIT
     assert "updated_at" in payload
 
     update_payload = {
         "provider": "llamacpp",
         "model": "llama-model",
         "temperature": 0.6,
-        "max_tokens": 20000,
+        "max_tokens": MAX_TOKENS_LIMIT,
         "api_key": "",
         "base_url": "http://localhost:9000",
     }
@@ -55,5 +56,5 @@ def test_model_settings_persist_between_requests(monkeypatch, tmp_path):
     assert persisted_payload["provider"] == "llamacpp"
     assert persisted_payload["model"] == "llama-model"
     assert persisted_payload["temperature"] == 0.6
-    assert persisted_payload["max_tokens"] == 20000
+    assert persisted_payload["max_tokens"] == MAX_TOKENS_LIMIT
     assert persisted_payload["base_url"] == "http://localhost:9000"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -59,7 +59,7 @@
               <label>Model <input type="text" name="model" placeholder="Model name" required /></label>
               <div class="grid">
                 <label>Temperature <input type="number" name="temperature" step="0.1" min="0" max="2" value="0.2" /></label>
-                <label>Max tokens <input type="number" name="max_tokens" min="16" max="8192" value="512" /></label>
+                <label>Max tokens <input type="number" name="max_tokens" min="16" max="8192" /></label>
               </div>
             </form>
           </section>

--- a/frontend/js/constants.js
+++ b/frontend/js/constants.js
@@ -1,0 +1,1 @@
+export const MAX_TOKENS_LIMIT = 20000;

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -20,6 +20,7 @@ import {
   resetLogs,
   markHeaderProcessed,
 } from "./state.js";
+import { MAX_TOKENS_LIMIT } from "./constants.js";
 import {
   renderHeadersTree,
   renderSidebarHeadersList,
@@ -377,7 +378,7 @@ function setupSettingsForm() {
       provider,
       model: (formData.get("model") || "").toString(),
       temperature: toNumber(formData.get("temperature"), 0.2),
-      maxTokens: toNumber(formData.get("max_tokens"), 512),
+      maxTokens: toNumber(formData.get("max_tokens"), MAX_TOKENS_LIMIT),
       apiKey: (formData.get("api_key") || "").toString(),
       baseUrl: (formData.get("base_url") || "").toString(),
     };
@@ -396,7 +397,7 @@ function setupSettingsForm() {
     provider: (response.provider || "openrouter").toString(),
     model: (response.model || "").toString(),
     temperature: typeof response.temperature === "number" ? response.temperature : 0.2,
-    maxTokens: typeof response.max_tokens === "number" ? response.max_tokens : 20000,
+    maxTokens: typeof response.max_tokens === "number" ? response.max_tokens : MAX_TOKENS_LIMIT,
     apiKey: (response.api_key || "").toString(),
     baseUrl: (response.base_url || "").toString(),
   });
@@ -428,7 +429,7 @@ function setupSettingsForm() {
       });
     settingsForm.querySelector('input[name="model"]').value = settingsData.model || "";
     settingsForm.querySelector('input[name="temperature"]').value = settingsData.temperature ?? 0.2;
-    settingsForm.querySelector('input[name="max_tokens"]').value = settingsData.maxTokens ?? 20000;
+    settingsForm.querySelector('input[name="max_tokens"]').value = settingsData.maxTokens ?? MAX_TOKENS_LIMIT;
     settingsForm.querySelector('input[name="api_key"]').value = settingsData.apiKey || "";
     settingsForm.querySelector('input[name="base_url"]').value = settingsData.baseUrl || "";
     syncProviderFields(provider);
@@ -453,6 +454,8 @@ function setupSettingsForm() {
     handleChange(true);
   });
   settingsForm.addEventListener("submit", (event) => event.preventDefault());
+
+  settingsForm.querySelector('input[name="max_tokens"]').value = MAX_TOKENS_LIMIT;
 
   const initialSettings = handleChange(false);
   lastPersistedSettings = toPayload(initialSettings);

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -1,3 +1,5 @@
+import { MAX_TOKENS_LIMIT } from "./constants.js";
+
 export const state = {
   uploadId: null,
   objects: [],
@@ -9,7 +11,7 @@ export const state = {
   model: "",
   params: {
     temperature: 0.2,
-    max_tokens: 512,
+    max_tokens: MAX_TOKENS_LIMIT,
   },
   apiKey: "",
   baseUrl: "",


### PR DESCRIPTION
## Summary
- add shared backend and frontend constants defining the max token limit at 20,000
- update model settings logic, defaults, and tests to rely on the shared constant instead of literals

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e01af581e08324bdeb2e15ccf2f1ab